### PR TITLE
Fixed endless loop due to the new next token, only request recursive if ...

### DIFF
--- a/src/LearnositySdk/Request/DataApi.php
+++ b/src/LearnositySdk/Request/DataApi.php
@@ -76,10 +76,12 @@ class DataApi
             } else {
                 throw new Exception(Json::encode($data));
             }
-            if (array_key_exists('next', $data['meta'])) {
+            if (array_key_exists('next', $data['meta']) && !empty($data['data'])) {
                 $requestPacket['next'] = $data['meta']['next'];
+            } else {
+                unset($requestPacket['next']);
             }
-        } while (array_key_exists('next', $data['meta']));
+        } while (array_key_exists('next', $requestPacket));
 
         return $response;
     }


### PR DESCRIPTION
...data is not empty

@michaelsharman FYI. This is reliant on the 'token meta inside data' bug being fixed. Bug been fixed with hotfix on staging today and will be released tomorrow v0.38.1. @klauste Can you please, review this? Thanks you :+1: 
