### PR TITLE
[BUG] Fix events api's request hash

### DIFF
--- a/src/LearnositySdk/Request/Init.php
+++ b/src/LearnositySdk/Request/Init.php
@@ -333,7 +333,7 @@ class Init
                 foreach ($this->requestPacket['users'] as $user) {
                     $hashedUsers[$user] = hash(
                         $this->algorithm,
-                        $user . $this->$secret
+                        $user . $this->secret
                     );
                 }
                 if (count($hashedUsers)) {


### PR DESCRIPTION
A typo was introduced in commit 1b519612c1ca4c066a4109004edc0c43d9f1cc6f