### PR TITLE
Adding support for loading the boostrap when imported by composer

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -14,4 +14,20 @@
  *
  */
 
-require_once __DIR__ . '/vendor/autoload.php';
+/**
+ * NOTE: Composer imports required libraries to
+ * vendor/<organization_namespace>/<project_namespace>
+ */
+$autoloadVendorDirs = [
+    __DIR__ . '/vendor', // standalone package
+    __DIR__ . '/../../../vendor', // composer vendored package
+];
+
+foreach ($autoloadVendorDirs as $vendorDir) {
+    $autoloadFile = "{$vendorDir}/autoload.php";
+
+    if (file_exists($autoloadFile)) {
+        require_once($autoloadFile);
+        break;
+    }
+}


### PR DESCRIPTION
This PR checks whether the Learnosity SDK is a standalone project or is
being imported as vendored project. It now allows the bootstrap to load
from both scenarios.