### PR TITLE
[BUILD] Don't use --long with git describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=$(shell git describe --long | sed s/^v//)
+VERSION=$(shell git describe | sed s/^v//)
 DIST_PREFIX=learnosity_sdk-
 DIST=$(DIST_PREFIX)$(VERSION)
 


### PR DESCRIPTION
We don't need git info in the version of tagged releases

Signed-off-by: Olivier Mehani <olivier.mehani@learnosity.com>