### PR TITLE
[BUG] Don't remove security.domain after signing api-questions requests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ### Fixed
 - Fixed the version range of `php` this library requires
+- No longer remove the `security.domain` from signed api-questions requests.
 
 ## [v0.10.3] - 2019-12-19
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DIST_PREFIX=learnosity_sdk-
 DIST=$(DIST_PREFIX)$(VERSION)
 
 COMPOSER=composer
-COMPOSER_INSTALL_FLAGS=--no-suggest --no-interaction
+COMPOSER_INSTALL_FLAGS=--no-interaction
 
 PHPUNIT=./vendor/bin/phpunit
 
@@ -49,8 +49,8 @@ dist-zip: clean
 	zip -qr $(DIST).zip $(DIST)
 
 # run tests in the distdir
-dist-test: dist-zip install-vendor-dev
-	$(PHPUNIT) -c $(DIST)/phpunit.xml
+dist-test: dist-zip
+	$(MAKE) -f $(PWD)/$(lastword $(MAKEFILE_LIST)) -C $(DIST) test
 
 ###
 # install vendor rules

--- a/examples/simple/init_questions.php
+++ b/examples/simple/init_questions.php
@@ -1,0 +1,26 @@
+<?php
+
+// Setup to load the necessary classes from the example directory
+require_once(__DIR__ . '/../../bootstrap.php');
+
+use LearnositySdk\Request\Init;
+
+$security_packet = [
+    'consumer_key'   => 'yis0TYCu7U9V4o7M',
+    'domain'         => 'localhost',
+    'timestamp'     => '20170727-2107',
+    'user_id'       => 'demo-user',
+];
+
+print_r($security_packet);
+
+# XXX: The consumer secret should be in a properly secured credential store, and *NEVER* checked in in revision control
+$consumer_secret = '74c5fd430cf1242a527f6223aebd42d30464be22';
+
+$init = new Init(
+    'questions',
+    $security_packet,
+    $consumer_secret
+);
+
+print_r(json_decode($init->generate()));

--- a/src/LearnositySdk/Request/Init.php
+++ b/src/LearnositySdk/Request/Init.php
@@ -190,7 +190,7 @@ class Init
             'platform_version' => php_uname('r')
         ];
 
-        if (isset($requestPacket['meta'])){
+        if (isset($requestPacket['meta'])) {
             $requestPacket['meta']['sdk'] = $sdkMetricsMeta;
         } else {
             $requestPacket['meta'] = [
@@ -258,9 +258,6 @@ class Init
             case 'questions':
                 // Add the security packet (with signature) to the root of output
                 $output = $this->securityPacket;
-
-                // Remove the `domain` key from the security packet
-                unset($output['domain']);
 
                 // Stringify the request packet if necessary
                 if (!empty($this->requestPacket)) {

--- a/src/tests/LearnositySdk/Request/InitTest.php
+++ b/src/tests/LearnositySdk/Request/InitTest.php
@@ -704,7 +704,7 @@ class InitTest extends \PHPUnit_Framework_TestCase
         /* Questions */
         list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
         $questionsApi = [
-            '{"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"03f4869659eeaca81077785135d5157874f4800e57752bf507891bf39c4d4a90","type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}]}',
+            '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"03f4869659eeaca81077785135d5157874f4800e57752bf507891bf39c4d4a90","type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}]}',
             new Init($service, $security, $secret, $request, $action)
         ];
         $testCases[] = $questionsApi;


### PR DESCRIPTION
When generating a signed request for api-questions, the `domain` is
removed from the security packet.

Signed-off-by: Olivier Mehani <olivier.mehani@learnosity.com>

## Checklist

- [ ] Feature
- [x] Bug

- [x] ChangeLog.md updated

- [ ] Tests added
- [x] All testsuite passes
- [x] `make dist` completed successfully
