### PR TITLE
Psre 2138/feature/pre hash string utils PSRE-2229

### DIFF
--- a/.github/workflows/push-pr-main-test-lint-unit.yml
+++ b/.github/workflows/push-pr-main-test-lint-unit.yml
@@ -1,0 +1,32 @@
+#####
+# Pull Request workflow triggers on pushes to, or pull requests against, main
+# Jobs performed:
+# 1. Lint
+# 2. Unit test
+# 3. Integration tests
+#####
+name: Tests
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      # Every push on those branches
+      - master
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    name: Lint & Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Run Lint Checks
+        run: make lint
+      - name: Run Python Tests
+        run: make test-unit
+      - name: Run Integration Test
+        run: make test-integration-env

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+  <description>PHP_CodeSniffer configuration</description>
+  <rule ref="PSR12"/>
+</ruleset>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added composable services for signature generation.
 - Support authoraide.
 
+### Refactor
+- Refactored the signature generation to use composable services.
+
+
 ## [v1.0.2] - 2023-07-03
 ### Added
 - PHP 7.1 is now the minimum supported version.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,14 +7,9 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [v1.0.3] - 2024-04-07
 ### Added
-- Rename author-aide to authoraide
-
-
-## [v1.0.3] - 2024-03-07
-### Added
-- Support author aide
+- Added composable services for signature generation.
+- Support authoraide.
 
 ## [v1.0.2] - 2023-07-03
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE = php-cli-composer:$(PHP_VERSION)
 TARGETS = all build devbuild prodbuild \
 	quickstart check-quickstart install-vendor \
 	dist dist-test dist-zip release \
-	test test-coverage test-integration-env test-unit \
+	lint test test-coverage test-integration-env test-unit \
 	clean clean-dist clean-test clean-vendor
 .PHONY: $(TARGETS)
 .default: all
@@ -39,6 +39,7 @@ DIST = $(DIST_PREFIX)$(SRC_VERSION)
 COMPOSER = composer
 COMPOSER_INSTALL_FLAGS = --no-interaction --optimize-autoloader --classmap-authoritative
 
+PHPCS= ./vendor/bin/phpcs
 PHPUNIT = ./vendor/bin/phpunit
 
 ###
@@ -62,6 +63,9 @@ prodbuild: install-vendor
 
 release:
 	@./release.sh
+
+lint: install-vendor
+	$(PHPCS) src
 
 test: install-vendor
 	$(PHPUNIT) --do-not-cache-result $(ARGS_PHPUNIT)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+ARGS_PHPUNIT ?=
+
 DOCKER := $(if $(LRN_SDK_NO_DOCKER),,$(shell which docker))
 PHP_VERSION = 8.3
 DEBIAN_VERSION = bookworm
@@ -62,16 +64,16 @@ release:
 	@./release.sh
 
 test: install-vendor
-	$(PHPUNIT) --do-not-cache-result
+	$(PHPUNIT) --do-not-cache-result $(ARGS_PHPUNIT)
 
 test-coverage: install-vendor
-	XDEBUG_MODE=coverage $(PHPUNIT) --do-not-cache-result
+	XDEBUG_MODE=coverage $(PHPUNIT) --do-not-cache-result $(ARGS_PHPUNIT)
 
 test-unit: install-vendor
-	$(PHPUNIT) --do-not-cache-result --testsuite unit
+	$(PHPUNIT) --do-not-cache-result --testsuite unit $(ARGS_PHPUNIT)
 
 test-integration-env: install-vendor
-	$(PHPUNIT) --do-not-cache-result --testsuite integration
+	$(PHPUNIT) --do-not-cache-result --testsuite integration $(ARGS_PHPUNIT)
 
 ###
 # dist rules

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DEBIAN_VERSION = bookworm
 IMAGE = php-cli-composer:$(PHP_VERSION)
 
 TARGETS = all build devbuild prodbuild \
-	quickstart install-vendor \
+	quickstart check-quickstart install-vendor \
 	dist dist-test dist-zip release \
 	test test-coverage test-integration-env test-unit \
 	clean clean-dist clean-test clean-vendor
@@ -46,6 +46,8 @@ quickstart: VENDOR_FLAGS = --no-dev
 quickstart: install-vendor
 	cd docs/quickstart && php -S $(LOCALHOST):8000
 
+check-quickstart: vendor/autoload.php
+	$(COMPOSER) install $(COMPOSER_INSTALL_FLAGS) --no-dev;
 ###
 # internal tooling rules
 ####

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "squizlabs/php_codesniffer": "*"
     }
 }

--- a/docs/quickstart/analytics/basic_data.php
+++ b/docs/quickstart/analytics/basic_data.php
@@ -1,9 +1,10 @@
 <?php
+
 /* Copyright (c) 2023 Learnosity, MIT License
  * Basic example code for pulling information from the Learnosity cloud using Data API. */
 
 // Setup to load the necessary classes from the example directory, & set up variables for access.
-require_once __DIR__ . '/../../../bootstrap.php'; 
+require_once __DIR__ . '/../../../bootstrap.php';
 $config = require_once __DIR__ . '/../config.php'; // Load security keys from config.php, for Learnosity's public demos account.
 use LearnositySdk\Request\DataApi; // Load core Data API library.
 $itembank_uri = 'https://data.learnosity.com/v2023.1.LTS/sessions/responses'; // Choosing the Data API endpoint for sessions/responses.

--- a/docs/quickstart/analytics/init_data.php
+++ b/docs/quickstart/analytics/init_data.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
      * Copyright (c) 2021 Learnosity, MIT License
      *

--- a/docs/quickstart/analytics/student-reporting.php
+++ b/docs/quickstart/analytics/student-reporting.php
@@ -1,4 +1,5 @@
 <?php
+
     /**
      * Copyright (c) 2021 Learnosity, MIT License
      *
@@ -55,9 +56,10 @@
         'reports',
         $security,
         $consumerSecret,
-        $request);
+        $request
+    );
     $initOptions = $init->generate();
-?>
+    ?>
 
 <!-- Section 2: Web page content. -->
 <!DOCTYPE html>

--- a/docs/quickstart/assessment/standalone-assessment.php
+++ b/docs/quickstart/assessment/standalone-assessment.php
@@ -1,4 +1,5 @@
 <?php
+
     /**
      * Copyright (c) 2021 Learnosity, MIT License
      *
@@ -60,9 +61,10 @@
         'items',
         $security,
         $consumerSecret,
-        $request);
+        $request
+    );
     $initOptions = $init->generate(); // JSON blob of signed config params.
-?>
+    ?>
 
 <!-- Section 2: Web page content. -->
 <!DOCTYPE html>

--- a/docs/quickstart/authoring/authoring-activities.php
+++ b/docs/quickstart/authoring/authoring-activities.php
@@ -1,4 +1,5 @@
 <?php
+
     /**
      * Copyright (c) 2021 Learnosity, MIT License
      *
@@ -40,9 +41,10 @@
         'author',
         $security,
         $consumerSecret,
-        $request);
+        $request
+    );
     $initOptions = $init->generate();
-?>
+    ?>
 
 <!-- Section 2: Web page content. -->
 <!DOCTYPE html>

--- a/docs/quickstart/authoring/authoring-items.php
+++ b/docs/quickstart/authoring/authoring-items.php
@@ -1,4 +1,5 @@
 <?php
+
     /**
      * Copyright (c) 2021 Learnosity, MIT License
      *
@@ -41,9 +42,10 @@
         'author',
         $security,
         $consumerSecret,
-        $request);
+        $request
+    );
     $initOptions = $init->generate(); // JSON blob of signed config params.
-?>
+    ?>
 
 <!-- Section 2: Web page content. -->
 <!DOCTYPE html>

--- a/docs/quickstart/config.php
+++ b/docs/quickstart/config.php
@@ -1,9 +1,10 @@
 <?php
+
     // The consumerKey and consumerSecret are the public & private
     // security keys required to access Learnosity APIs and
     // data. Learnosity will provide keys for your own private account.
-    // Note: The consumer secret should be in a properly secured credential store, 
-    // and *NEVER* checked into version control. 
+    // Note: The consumer secret should be in a properly secured credential store,
+    // and *NEVER* checked into version control.
     // The keys listed here grant access to Learnosity's public demos account.
 return [
     'consumerKey' => 'yis0TYCu7U9V4o7M',

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,30 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        backupGlobals="false"
-        backupStaticAttributes="false"
-        bootstrap="bootstrap.php"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        processIsolation="false"
-        stopOnFailure="false"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="bootstrap.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+    <report>
+      <clover outputFile="./tests/coverage.xml"/>
+      <html outputDirectory="./tests/coverage" lowUpperBound="35" highLowerBound="70"/>
+    </report>
+  </coverage>
   <php>
-    <ini name="intl.default_locale" value="en" />
-    <ini name="intl.error_level" value="0" />
-    <ini name="memory_limit" value="-1" />
+    <ini name="intl.default_locale" value="en"/>
+    <ini name="intl.error_level" value="0"/>
+    <ini name="memory_limit" value="-1"/>
   </php>
   <logging>
-    <log type="coverage-html" target="./tests/coverage" lowUpperBound="35" highLowerBound="70" />
-    <log type="coverage-clover" target="./tests/coverage.xml" />
-    <log type="junit" target="./tests/junit.xml" />
+    <junit outputFile="./tests/junit.xml"/>
   </logging>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./src/</directory>
-    </whitelist>
-  </filter>
   <testsuites>
     <testsuite name="unit">
       <directory>./tests/</directory>

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace LearnositySdk\Exceptions;
 
 use Exception;
 
 class ValidationException extends Exception
 {
-
 }

--- a/src/Request/Init.php
+++ b/src/Request/Init.php
@@ -20,12 +20,12 @@ use LearnositySdk\Services\SignatureFactory;
 
 class Init
 {
-    const VERSION_FILE_PATH = __DIR__ . '/../../.version';
+    protected const VERSION_FILE_PATH = __DIR__ . '/../../.version';
 
     /**
-     * The algorithm used in the hashing function to create the signature
+     * The algorithm used in the hashing function to create the api-events signature
      */
-    const ALGORITHM = 'sha256';
+    protected const ALGORITHM = 'sha256';
 
     /**
      * We use telemetry to enable better support and feature planning. It is however not advised to

--- a/src/SdkFactory.php
+++ b/src/SdkFactory.php
@@ -7,8 +7,8 @@ use LearnositySdk\Request\Init;
 
 class SdkFactory
 {
-    const REQUIRED_ARGUMENTS = ['service', 'securityPacket', 'secret'];
-    const OPTIONAL_ARGUMENTS = ['requestPacket', 'action', 'signatureFactory'];
+    private const REQUIRED_ARGUMENTS = ['service', 'securityPacket', 'secret'];
+    private const OPTIONAL_ARGUMENTS = ['requestPacket', 'action', 'signatureFactory'];
 
 
     /**

--- a/src/Services/PreHashStringFactory.php
+++ b/src/Services/PreHashStringFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace LearnositySdk\Services;
+
+use LearnositySdk\Exceptions\ValidationException;
+use LearnositySdk\Services\PreHashStrings\PreHashStringInterface;
+use LearnositySdk\Services\PreHashStrings\LegacyPreHashString;
+
+class PreHashStringFactory
+{
+    protected const PRE_HASH_STRING_GENERATORS = [
+        /* Add newer services at the top, so they are chosen in priority */
+        LegacyPreHashString::class,
+    ];
+
+    protected array $validServices;
+
+    public function __construct()
+    {
+        $this->validServices = $this->buildValidServices(static::PRE_HASH_STRING_GENERATORS);
+    }
+
+    protected function buildValidServices(array $preHashStringGenerators): array
+    {
+        $validServices = [];
+
+        foreach ($preHashStringGenerators as $preHashStringGenerator) {
+            $validServices = array_merge($validServices, $preHashStringGenerator::getSupportedServices());
+        }
+
+        return $validServices;
+    }
+
+    public function getValidServices(): array
+    {
+        return $this->validServices;
+    }
+
+    /**
+     * @param string $service
+     * @param string $v1Compat whether a legacy pre-hash string for v1 signature format should be created
+     * @return PreHashStringInterface
+     * @throws \Exception
+     */
+    public function getPreHashStringGenerator(string $service, bool $v1Compat = false): PreHashStringInterface
+    {
+        if (empty($service)) {
+            throw new ValidationException('The `service` argument wasn\'t found or was empty');
+        }
+        $service = strtolower($service);
+
+        foreach (static::PRE_HASH_STRING_GENERATORS as $preHashStringGenerator) {
+            if ($preHashStringGenerator::supportsService($service)) {
+                return new $preHashStringGenerator($service, $v1Compat);
+            }
+        }
+        throw new ValidationException("The service provided ($service) is not valid");
+    }
+}

--- a/src/Services/PreHashStrings/LegacyPreHashString.php
+++ b/src/Services/PreHashStrings/LegacyPreHashString.php
@@ -76,7 +76,7 @@ class LegacyPreHashString implements PreHashStringInterface
      * @var array
      * TODO: make this protected when the legacy signing code is gone
      */
-    public const VALID_SECURITY_KEYS = [
+    protected const VALID_SECURITY_KEYS = [
         'consumer_key',
         'domain',
         'timestamp',

--- a/src/Services/PreHashStrings/LegacyPreHashString.php
+++ b/src/Services/PreHashStrings/LegacyPreHashString.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace LearnositySdk\Services\PreHashStrings;
+
+use LearnositySdk\Exceptions\ValidationException;
+
+class LegacyPreHashString implements PreHashStringInterface
+{
+    protected const SERVICE_ASSESS_API = 'assess';
+    protected const SERVICE_ANNOTATIONS_API = 'annotations';
+    protected const SERVICE_AUTHOR_API = 'author';
+    protected const SERVICE_AUTHOR_AIDE_API = 'author-aide';
+    protected const SERVICE_DATA_API = 'data';
+    protected const SERVICE_EVENTS_API = 'events';
+    protected const SERVICE_ITEMS_API = 'items';
+    protected const SERVICE_QUESTIONS_API = 'questions';
+    protected const SERVICE_REPORTS_API = 'reports';
+
+    /**
+     * Service names that are valid for `$service`
+     * @var array
+     */
+    protected const SUPPORTED_SERVICES = [
+        self::SERVICE_ASSESS_API,
+        self::SERVICE_AUTHOR_API,
+        self::SERVICE_AUTHOR_AIDE_API,
+        self::SERVICE_DATA_API,
+        self::SERVICE_EVENTS_API,
+        self::SERVICE_ITEMS_API,
+        self::SERVICE_QUESTIONS_API,
+        self::SERVICE_REPORTS_API,
+    ];
+
+    /**
+     * Services that don't use `user_id` as part
+     * of the security/signature
+     *
+     * @var array
+     */
+    protected const SERVICES_NOT_REQUIRING_USER_ID = [
+        self::SERVICE_ANNOTATIONS_API,
+        self::SERVICE_AUTHOR_API,
+        self::SERVICE_AUTHOR_AIDE_API,
+        self::SERVICE_DATA_API,
+        self::SERVICE_EVENTS_API,
+        self::SERVICE_REPORTS_API,
+    ];
+
+    /**
+     * Services that require the action attribute to be part
+     * of the signature
+     *
+     * @var array
+     */
+    protected const SERVICES_REQUIRING_SIGNED_REQUEST = [
+        self::SERVICE_AUTHOR_API,
+        self::SERVICE_AUTHOR_AIDE_API,
+        self::SERVICE_ITEMS_API,
+        self::SERVICE_DATA_API,
+        self::SERVICE_REPORTS_API,
+    ];
+
+    /**
+     * Services that require the action attribute to be part
+     * of the signature
+     *
+     * @var array
+     */
+    protected const SERVICES_REQUIRING_SIGNED_ACTION = [
+        self::SERVICE_DATA_API,
+    ];
+
+    /**
+     * Keynames that are valid in the securityPacket, they are also in
+     * the correct order for signature generation.
+     * @var array
+     * TODO: make this protected when the legacy signing code is gone
+     */
+    public const VALID_SECURITY_KEYS = [
+        'consumer_key',
+        'domain',
+        'timestamp',
+        'expires',
+        'user_id',
+    ];
+
+    /**
+     * Keynames that are mandatory in the securityPacket.
+     * @var array
+     * TODO: make this protected when the legacy signing code is gone
+     */
+    public const MANDATORY_SECURITY_KEYS = [
+        'consumer_key',
+        'domain',
+    ];
+
+    /** Service name to generate a pre-hash string for */
+    protected string $service;
+
+    /** V1-compat strings need the secret to be part of the pre-hash string */
+    protected bool $v1Compat;
+
+    public function __construct(string $service, bool $v1Compat = false)
+    {
+        $this->service = $service;
+        $this->v1Compat = $v1Compat;
+    }
+
+    public function getPreHashString(
+        array $security,
+        array $request,
+        ?string $action = 'get',
+        ?string $secret = null
+    ): string {
+        $signatureArray = [
+            $security['consumer_key'],
+            $security['domain'],
+            $security['timestamp'],
+        ];
+
+        if (isset($security['expires'])) {
+            $signatureArray[] = $security['expires'];
+        }
+        if (!in_array($this->service, static::SERVICES_NOT_REQUIRING_USER_ID)) { // || isset($security['user_id'])) {
+            $signatureArray[] = $security['user_id'];
+        }
+
+        if ($this->v1Compat) {
+            if (empty($secret)) {
+                throw new ValidationException('Pre-hash strings require a secret in v1-compat mode');
+            }
+            $signatureArray[] = $secret;
+        } elseif (!empty($secret)) {
+            throw new ValidationException('Pre-hash strings do not need a secret');
+        }
+
+        if (in_array($this->service, static::SERVICES_REQUIRING_SIGNED_REQUEST)) {
+            $requestJson = $request;
+            if (is_array($request)) {
+                $requestJson = json_encode($request, true);
+            }
+            $signatureArray[] = $requestJson;
+        }
+
+        if (in_array($this->service, static::SERVICES_REQUIRING_SIGNED_ACTION)) {
+            if (empty($action)) {
+                $action = 'get';
+            }
+            $signatureArray[] = $action;
+        }
+
+        return implode('_', $signatureArray);
+    }
+
+    public static function getSupportedServices(): array
+    {
+        return static::SUPPORTED_SERVICES;
+    }
+
+    public static function supportsService(string $service): bool
+    {
+        return in_array($service, static::SUPPORTED_SERVICES);
+    }
+
+    public function validate(array $security, array $request): array
+    {
+        foreach (array_keys($security) as $key) {
+            if (!in_array($key, static::VALID_SECURITY_KEYS)) {
+                throw new ValidationException('Invalid key found in the security packet: ' . $key);
+            }
+        }
+        foreach (static::MANDATORY_SECURITY_KEYS as $key) {
+            if (!key_exists($key, $security)) {
+                throw new ValidationException('Missing key from the security packet: ' . $key);
+            }
+        }
+
+        /* Add timestamp if not present */
+        if (!array_key_exists('timestamp', $security)) {
+            $security['timestamp'] = gmdate('Ymd-Hi');
+        }
+
+        /* XXXX move to question prehash string */
+        if ($this->service === "questions" && !array_key_exists('user_id', $security)) {
+            throw new ValidationException('Questions API requires a `user_id` in the security packet');
+        }
+        /* end XXX */
+
+        return [ $request, $security ];
+    }
+}

--- a/src/Services/PreHashStrings/LegacyPreHashString.php
+++ b/src/Services/PreHashStrings/LegacyPreHashString.php
@@ -9,7 +9,7 @@ class LegacyPreHashString implements PreHashStringInterface
     protected const SERVICE_ASSESS_API = 'assess';
     protected const SERVICE_ANNOTATIONS_API = 'annotations';
     protected const SERVICE_AUTHOR_API = 'author';
-    protected const SERVICE_AUTHOR_AIDE_API = 'author-aide';
+    protected const SERVICE_AUTHOR_AIDE_API = 'authoraide';
     protected const SERVICE_DATA_API = 'data';
     protected const SERVICE_EVENTS_API = 'events';
     protected const SERVICE_ITEMS_API = 'items';

--- a/src/Services/PreHashStrings/LegacyPreHashString.php
+++ b/src/Services/PreHashStrings/LegacyPreHashString.php
@@ -108,7 +108,7 @@ class LegacyPreHashString implements PreHashStringInterface
 
     public function getPreHashString(
         array $security,
-        array $request,
+        ?array $request,
         ?string $action = 'get',
         ?string $secret = null
     ): string {

--- a/src/Services/PreHashStrings/PreHashStringInterface.php
+++ b/src/Services/PreHashStrings/PreHashStringInterface.php
@@ -6,12 +6,12 @@ interface PreHashStringInterface
 {
     /* Generate a string ready to be signed
      * @param array $security
-     * @param array $request
+     * @param array|null $request
      * @param string|null $action
      * @param string|null $secret only for legacy pre-hash string generation when $v1Compat is true
      * @return string the pre-hash string
      */
-    public function getPreHashString(array $security, array $request, ?string $action, ?string $secret): string;
+    public function getPreHashString(array $security, ?array $request, ?string $action, ?string $secret): string;
 
     /** Return a list of all supported services
      * @return string[]

--- a/src/Services/PreHashStrings/PreHashStringInterface.php
+++ b/src/Services/PreHashStrings/PreHashStringInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LearnositySdk\Services\PreHashStrings;
+
+interface PreHashStringInterface
+{
+    /* Generate a string ready to be signed
+     * @param array $security
+     * @param array $request
+     * @param string|null $action
+     * @param string|null $secret only for legacy pre-hash string generation when $v1Compat is true
+     * @return string the pre-hash string
+     */
+    public function getPreHashString(array $security, array $request, ?string $action, ?string $secret): string;
+
+    /** Return a list of all supported services
+     * @return string[]
+     */
+    public static function getSupportedServices(): array;
+
+    /** Return true if the service is supported
+     * @param string $service
+     * @return bool
+     */
+    public static function supportsService(string $service): bool;
+
+    /** Validate a request to be signed, and return a potentially modified request
+     * @param array $security
+     * @param array $request
+     * @return array <$updatedRequest, $updatedSecurity>
+     * */
+    public function validate(array $security, array $request): array;
+}

--- a/src/Services/Signatures/HashSignature.php
+++ b/src/Services/Signatures/HashSignature.php
@@ -53,5 +53,4 @@ class HashSignature implements SignatureInterface
     {
         return static::SIGNATURE_VERSION;
     }
-
 }

--- a/src/Services/Signatures/HashSignature.php
+++ b/src/Services/Signatures/HashSignature.php
@@ -6,17 +6,17 @@ use LearnositySdk\Exceptions\ValidationException;
 
 class HashSignature implements SignatureInterface
 {
-    public const ALGORITHM = 'sha256';
-
     public const SIGNATURE_VERSION = '01';
 
-    public const CONSUMER_KEY_LENGTH = 16;
+    private const ALGORITHM = 'sha256';
 
-    public const TIMESTAMP_KEY_LENGTH = 13;
+    private const CONSUMER_KEY_LENGTH = 16;
 
-    public const SIGNATURE_KEY_LENGTH = 64;
+    private const TIMESTAMP_KEY_LENGTH = 13;
 
-    public const EXCEPTION_MESSAGE =
+    private const SIGNATURE_KEY_LENGTH = 64;
+
+    private const EXCEPTION_MESSAGE =
         'The pre hash string for this signature type must contain the secret key';
 
     /**

--- a/src/Services/Signatures/HashSignature.php
+++ b/src/Services/Signatures/HashSignature.php
@@ -6,17 +6,17 @@ use LearnositySdk\Exceptions\ValidationException;
 
 class HashSignature implements SignatureInterface
 {
-    const ALGORITHM = 'sha256';
+    public const ALGORITHM = 'sha256';
 
-    const SIGNATURE_VERSION = '01';
+    public const SIGNATURE_VERSION = '01';
 
-    const CONSUMER_KEY_LENGTH = 16;
+    public const CONSUMER_KEY_LENGTH = 16;
 
-    const TIMESTAMP_KEY_LENGTH = 13;
+    public const TIMESTAMP_KEY_LENGTH = 13;
 
-    const SIGNATURE_KEY_LENGTH = 64;
+    public const SIGNATURE_KEY_LENGTH = 64;
 
-    const EXCEPTION_MESSAGE =
+    public const EXCEPTION_MESSAGE =
         'The pre hash string for this signature type must contain the secret key';
 
     /**

--- a/src/Services/Signatures/HmacSignature.php
+++ b/src/Services/Signatures/HmacSignature.php
@@ -34,7 +34,8 @@ class HmacSignature implements SignatureInterface
         if (strpos($preHashString, $secretKey)) {
             throw new ValidationException(static::EXCEPTION_MESSAGE);
         }
-        return '$' . static::SIGNATURE_VERSION . '$' . hash_hmac(static::ALGORITHM,
+        return '$' . static::SIGNATURE_VERSION . '$' . hash_hmac(
+            static::ALGORITHM,
             $preHashString,
             $secretKey
         );
@@ -58,5 +59,4 @@ class HmacSignature implements SignatureInterface
     {
         return static::SIGNATURE_VERSION;
     }
-
 }

--- a/src/Services/Signatures/HmacSignature.php
+++ b/src/Services/Signatures/HmacSignature.php
@@ -8,17 +8,17 @@ use LearnositySdk\Exceptions\ValidationException;
 
 class HmacSignature implements SignatureInterface
 {
-    public const ALGORITHM = 'sha256';
-
     public const SIGNATURE_VERSION = '02';
 
-    public const CONSUMER_KEY_LENGTH = 16;
+    private const ALGORITHM = 'sha256';
 
-    public const TIMESTAMP_KEY_LENGTH = 13;
+    private const CONSUMER_KEY_LENGTH = 16;
 
-    public const SIGNATURE_KEY_LENGTH = 68;
+    private const TIMESTAMP_KEY_LENGTH = 13;
 
-    public const EXCEPTION_MESSAGE =
+    private const SIGNATURE_KEY_LENGTH = 68;
+
+    private const EXCEPTION_MESSAGE =
         'The pre hash string for this signature type must not contain the secret key';
 
     /**

--- a/src/Services/Signatures/HmacSignature.php
+++ b/src/Services/Signatures/HmacSignature.php
@@ -8,17 +8,17 @@ use LearnositySdk\Exceptions\ValidationException;
 
 class HmacSignature implements SignatureInterface
 {
-    const ALGORITHM = 'sha256';
+    public const ALGORITHM = 'sha256';
 
-    const SIGNATURE_VERSION = '02';
+    public const SIGNATURE_VERSION = '02';
 
-    const CONSUMER_KEY_LENGTH = 16;
+    public const CONSUMER_KEY_LENGTH = 16;
 
-    const TIMESTAMP_KEY_LENGTH = 13;
+    public const TIMESTAMP_KEY_LENGTH = 13;
 
-    const SIGNATURE_KEY_LENGTH = 68;
+    public const SIGNATURE_KEY_LENGTH = 68;
 
-    const EXCEPTION_MESSAGE =
+    public const EXCEPTION_MESSAGE =
         'The pre hash string for this signature type must not contain the secret key';
 
     /**

--- a/src/Services/Signatures/SignatureInterface.php
+++ b/src/Services/Signatures/SignatureInterface.php
@@ -17,5 +17,4 @@ interface SignatureInterface
     public function validateParameterLengths(array $security): bool;
 
     public function getVersion(): string;
-
 }

--- a/src/Utils/Json.php
+++ b/src/Utils/Json.php
@@ -53,7 +53,7 @@ class Json
 
         $highPrecisionFloatMap = static::getHighPrecisionFloatMap($array);
 
-        $jsonOptions = JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES;
+        $jsonOptions = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
         if (!empty($options)) {
             foreach ($options as $o) {
                 $jsonOptions += $o;
@@ -62,7 +62,7 @@ class Json
 
         $result = json_encode($array, (int)$jsonOptions);
 
-        foreach($highPrecisionFloatMap as $scientificValueString => $floatValueString) {
+        foreach ($highPrecisionFloatMap as $scientificValueString => $floatValueString) {
             // Replace all scientific values by equivalent floatValues
             $result = str_ireplace($scientificValueString, $floatValueString, $result);
         }

--- a/src/Utils/Uuid.php
+++ b/src/Utils/Uuid.php
@@ -48,8 +48,8 @@ class Uuid
         $nstr = '';
 
         // Convert Namespace UUID to bits
-        for ($i = 0; $i < strlen($nhex); $i+=2) {
-            $nstr .= chr(hexdec($nhex[$i].$nhex[$i+1]));
+        for ($i = 0; $i < strlen($nhex); $i += 2) {
+            $nstr .= chr(hexdec($nhex[$i] . $nhex[$i + 1]));
         }
 
         // Calculate hash value
@@ -150,8 +150,8 @@ class Uuid
         $nstr = '';
 
         // Convert Namespace UUID to bits
-        for ($i = 0; $i < strlen($nhex); $i+=2) {
-            $nstr .= chr(hexdec($nhex[$i].$nhex[$i+1]));
+        for ($i = 0; $i < strlen($nhex); $i += 2) {
+            $nstr .= chr(hexdec($nhex[$i] . $nhex[$i + 1]));
         }
 
         // Calculate hash value

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -6,16 +6,4 @@ use PHPUnit\Framework\TestCase;
 
 class AbstractTestCase extends TestCase
 {
-    const TEST_CONSUMER_KEY = 'yis0TYCu7U9V4o7M';
-    const TEST_CONSUMER_SECRET = '74c5fd430cf1242a527f6223aebd42d30464be22';
-    const TEST_DOMAIN = 'localhost';
-
-    public static function getSecurity(): array
-    {
-        return [
-            'consumer_key' => static::TEST_CONSUMER_KEY,
-            'domain'       => static::TEST_DOMAIN,
-            'timestamp'    => '20140626-0528',
-        ];
-    }
 }

--- a/tests/Fixtures/ParamsFixture.php
+++ b/tests/Fixtures/ParamsFixture.php
@@ -30,6 +30,13 @@ class ParamsFixture
         // Needed to initialise Questions API
         $security['user_id'] = '$ANONYMIZED_USER_ID';
         $secret = static::TEST_CONSUMER_SECRET;
+
+        $questionsParams = static::getWorkingQuestionsApiParams(true);
+        $questionsApiActivity = $questionsParams['request'];
+        $questionsApiActivity['user_id'] = $security['user_id'];
+        $questionsApiActivity['name'] = 'Assess API - Demo';
+        $questionsApiActivity['id'] = 'assessdemo';
+
         $request = [
             "items" => [
                 [
@@ -75,37 +82,7 @@ class ParamsFixture
                 "idle_timeout" => true,
                 "questionsApiVersion" => "v2"
             ],
-            "questionsApiActivity" => [
-                "user_id" => '$ANONYMIZED_USER_ID',
-                "type" => "submit_practice",
-                "state" => "initial",
-                "id" => "assessdemo",
-                "name" => "Assess API - Demo",
-                "questions" => [
-                    [
-                        "response_id" => "demoscience1234",
-                        "type" => "sortlist",
-                        "description" => "In this question, the student needs to sort the events, chronologically earliest to latest.",
-                        "list" => ["Russian Revolution", "Discovery of the Americas", "Storming of the Bastille", "Battle of Plataea", "Founding of Rome", "First Crusade"],
-                        "instant_feedback" => true,
-                        "feedback_attempts" => 2,
-                        "validation" => [
-                            "valid_response" => [4, 3, 5, 1, 2, 0],
-                            "valid_score" => 1,
-                            "partial_scoring" => true,
-                            "penalty_score" => -1
-                        ]
-                    ],
-                    [
-                        "response_id" => "demoscience5678",
-                        "type" => "highlight",
-                        "description" => "The student needs to mark one of the flowers anthers in the image.",
-                        "img_src" => "http://www.learnosity.com/static/img/flower.jpg",
-                        "line_color" => "rgb(255, 20, 0)",
-                        "line_width" => "4"
-                    ]
-                ]
-            ],
+            "questionsApiActivity" => $questionsApiActivity,
             "type" => "activity"
         ];
         $action = null;
@@ -224,6 +201,7 @@ class ParamsFixture
     {
         $service = 'data';
         $security = static::getSecurity();
+        $security['timestamp'] = '20140626-0528';
         $secret = static::TEST_CONSUMER_SECRET;
         $request = [
             'limit' => 100,
@@ -295,6 +273,7 @@ class ParamsFixture
     {
         $service = 'items';
         $security = static::getSecurity();
+        $security['user_id'] = '$ANONYMIZED_USER_ID';
         $secret = static::TEST_CONSUMER_SECRET;
         $request = [
             'user_id' => '$ANONYMIZED_USER_ID',

--- a/tests/Fixtures/ParamsFixture.php
+++ b/tests/Fixtures/ParamsFixture.php
@@ -2,6 +2,8 @@
 
 namespace LearnositySdk\Fixtures;
 
+use LearnositySdk\Services\Signatures\HmacSignature;
+
 // XXX: should be in a Test namespace
 
 class ParamsFixture
@@ -17,6 +19,50 @@ class ParamsFixture
             'domain'       => static::TEST_DOMAIN,
             'timestamp'    => '20140626-0528',
         ];
+    }
+
+    /**
+     * @param  bool $assoc If true, associative array will be returned
+     * @return array
+     */
+    public static function getWorkingParamsForService(string $service, bool $assoc = false): array
+    {
+        $camelCaseService = static::kebab2Camel($service);
+        $getParams = 'getWorking' . $camelCaseService . 'ApiParams';
+
+        return static::$getParams($assoc);
+    }
+
+    /**
+     * Return the signature of the selected version for the working params for this service.
+     *
+     * The signature may be an empty string if the deprecation of the signature version predates the introduction of the
+     * service.
+     *
+     * @return string $service
+     * @param  string $signatureVersion, defaults to the HMAC's version (02)
+     */
+    public static function getSignatureForService(
+        string $service,
+        string $signatureVersion = HmacSignature::SIGNATURE_VERSION
+    ): string {
+        $camelCaseService = static::kebab2Camel($service);
+        $getSig = 'get' . ucfirst($camelCaseService) . 'ApiSignatureForVersion';
+
+        return static::$getSig($signatureVersion);
+    }
+
+    /* Convert kebab-case to camelCase
+     * @param string $kebab
+     * @return string CamelCase
+     */
+    protected static function kebab2Camel(string $kebab): string
+    {
+        return str_replace(
+            ' ',
+            '',
+            ucwords(str_replace('-', ' ', $kebab))
+        );
     }
 
     /**
@@ -197,9 +243,19 @@ class ParamsFixture
         return $params;
     }
 
+    /**
+     * Return the signature of the selected version for the working params for this service.
+     * The signature may be an empty string if the deprecation of the signature version predates the introduction of the
+     * service
+     * @param  string $version
+     * @return string
+     * @see getWorkingAuthorAideApiParams
+     */
     public static function getAuthorAideApiSignatureForVersion(string $version): string
     {
         switch ($version) {
+            case '01':
+                return '';
             case '02':
                 return '$02$f2ce1da2fdead193d53ab954b8a3660548ed9b0e3ce60599d751130deba7a138';
             default:

--- a/tests/Fixtures/ParamsFixture.php
+++ b/tests/Fixtures/ParamsFixture.php
@@ -1,0 +1,450 @@
+<?php
+
+namespace LearnositySdk\Fixtures;
+
+// XXX: should be in a Test namespace
+
+class ParamsFixture
+{
+    const TEST_CONSUMER_KEY = 'yis0TYCu7U9V4o7M';
+    const TEST_CONSUMER_SECRET = '74c5fd430cf1242a527f6223aebd42d30464be22';
+    const TEST_DOMAIN = 'localhost';
+
+    public static function getSecurity(): array
+    {
+        return [
+            'consumer_key' => static::TEST_CONSUMER_KEY,
+            'domain'       => static::TEST_DOMAIN,
+            'timestamp'    => '20140626-0528',
+        ];
+    }
+
+    /**
+     * @param  bool $assoc If true, associative array will be returned
+     * @return array
+     */
+    public static function getWorkingAssessApiParams(bool $assoc = false): array
+    {
+        $service = 'assess';
+        $security = static::getSecurity();
+        // Needed to initialise Questions API
+        $security['user_id'] = '$ANONYMIZED_USER_ID';
+        $secret = static::TEST_CONSUMER_SECRET;
+        $request = [
+            "items" => [
+                [
+                    "content" => '<span class="learnosity-response question-demoscience1234"></span>',
+                    "response_ids" => [
+                        "demoscience1234"
+                    ],
+                    "workflow" => "",
+                    "reference" => "question-demoscience1"
+                ],
+                [
+                    "content" => '<span class="learnosity-response question-demoscience5678"></span>',
+                    "response_ids" => [
+                        "demoscience5678"
+                    ],
+                    "workflow" => "",
+                    "reference" => "question-demoscience2"
+                ]
+            ],
+            "ui_style" => "horizontal",
+            "name" => "Demo (2 questions)",
+            "state" => "initial",
+            "metadata" => [],
+            "navigation" => [
+                "show_next" => true,
+                "toc" => true,
+                "show_submit" => true,
+                "show_save" => false,
+                "show_prev" => true,
+                "show_title" => true,
+                "show_intro" => true,
+            ],
+            "time" => [
+                "max_time" => 600,
+                "limit_type" => "soft",
+                "show_pause" => true,
+                "warning_time" => 60,
+                "show_time" => true
+            ],
+            "configuration" => [
+                "onsubmit_redirect_url" => "/assessment/",
+                "onsave_redirect_url" => "/assessment/",
+                "idle_timeout" => true,
+                "questionsApiVersion" => "v2"
+            ],
+            "questionsApiActivity" => [
+                "user_id" => '$ANONYMIZED_USER_ID',
+                "type" => "submit_practice",
+                "state" => "initial",
+                "id" => "assessdemo",
+                "name" => "Assess API - Demo",
+                "questions" => [
+                    [
+                        "response_id" => "demoscience1234",
+                        "type" => "sortlist",
+                        "description" => "In this question, the student needs to sort the events, chronologically earliest to latest.",
+                        "list" => ["Russian Revolution", "Discovery of the Americas", "Storming of the Bastille", "Battle of Plataea", "Founding of Rome", "First Crusade"],
+                        "instant_feedback" => true,
+                        "feedback_attempts" => 2,
+                        "validation" => [
+                            "valid_response" => [4, 3, 5, 1, 2, 0],
+                            "valid_score" => 1,
+                            "partial_scoring" => true,
+                            "penalty_score" => -1
+                        ]
+                    ],
+                    [
+                        "response_id" => "demoscience5678",
+                        "type" => "highlight",
+                        "description" => "The student needs to mark one of the flowers anthers in the image.",
+                        "img_src" => "http://www.learnosity.com/static/img/flower.jpg",
+                        "line_color" => "rgb(255, 20, 0)",
+                        "line_width" => "4"
+                    ]
+                ]
+            ],
+            "type" => "activity"
+        ];
+        $action = null;
+
+        if ($assoc) {
+            return [
+                'service' => $service,
+                'security' => $security,
+                'secret' => $secret,
+                'request' => $request,
+                'action' => $action,
+            ];
+        } else {
+            return [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action,
+            ];
+        }
+    }
+
+    /**
+     * @param  bool $assoc If true, associative array will be returned
+     * @return array
+     */
+    public static function getWorkingAuthorApiParams(bool $assoc = false): array
+    {
+        $service = 'author';
+        $security = static::getSecurity();
+        $secret = static::TEST_CONSUMER_SECRET;
+        $request = [
+            "mode" => "item_list",
+            "config" => [
+                "item_list" => [
+                    "item" => [
+                        "status" => true
+                    ]
+                ]
+            ],
+            "user" => [
+                "id" => "walterwhite",
+                "firstname" => "walter",
+                "lastname" => "white"
+            ]
+        ];
+        $action = null;
+
+        if ($assoc) {
+            return [
+                'service' => $service,
+                'security' => $security,
+                'secret' => $secret,
+                'request' => $request,
+                'action' => $action,
+            ];
+        } else {
+            return [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action,
+            ];
+        }
+    }
+
+    /**
+     * @param  bool $assoc If true, associative array will be returned
+     * @return array
+     */
+    public static function getWorkingAuthorAideApiParams(bool $assoc = false): array
+    {
+        $service = 'authoraide';
+        $security = static::getSecurity();
+        $secret = static::TEST_CONSUMER_SECRET;
+        $request = [
+            "config" => [
+                "test-attribute" => "test"
+            ],
+            "user" => [
+                "id" => "walterwhite",
+                "firstname" => "walter",
+                "lastname" => "white"
+            ]
+        ];
+        $action = null;
+
+        if ($assoc) {
+            return [
+                'service' => $service,
+                'security' => $security,
+                'secret' => $secret,
+                'request' => $request,
+                'action' => $action,
+            ];
+        } else {
+            return [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action,
+            ];
+        }
+    }
+
+    /**
+     * WARNING: RemoteTest is also using this params
+     *
+     * @param  bool $assoc If true, associative array will be returned
+     * @return array
+     */
+    public static function getWorkingDataApiParams(bool $assoc = false): array
+    {
+        $service = 'data';
+        $security = static::getSecurity();
+        $secret = static::TEST_CONSUMER_SECRET;
+        $request = [
+            'limit' => 100,
+        ];
+        $action = 'get';
+
+        if ($assoc) {
+            return [
+                'service' => $service,
+                'security' => $security,
+                'secret' => $secret,
+                'request' => $request,
+                'action' => $action,
+            ];
+        } else {
+            return [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action
+            ];
+        }
+    }
+
+    /**
+     * @param  bool $assoc If true, associative array will be returned
+     * @return array
+     */
+    public static function getWorkingEventsApiParams(bool $assoc = false): array
+    {
+        $service = 'events';
+        $security = static::getSecurity();
+        $secret = static::TEST_CONSUMER_SECRET;
+        $request = [
+            'users' => [
+                '$ANONYMIZED_USER_ID_1' => '$ANONYMIZED_USER_ID_1_NAME',
+                '$ANONYMIZED_USER_ID_2' => '$ANONYMIZED_USER_ID_2_NAME',
+                '$ANONYMIZED_USER_ID_3' => '$ANONYMIZED_USER_ID_3_NAME',
+                '$ANONYMIZED_USER_ID_4' => '$ANONYMIZED_USER_ID_4_NAME'
+            ]
+        ];
+        $action = null;
+
+        if ($assoc) {
+            return [
+                'service' => $service,
+                'security' => $security,
+                'secret' => $secret,
+                'request' => $request,
+                'action' => $action,
+            ];
+        } else {
+            return [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action,
+            ];
+        }
+    }
+
+    /**
+     * @param  bool $assoc If true, associative array will be returned
+     * @return array
+     */
+    public static function getWorkingItemsApiParams(bool $assoc = false): array
+    {
+        $service = 'items';
+        $security = static::getSecurity();
+        $secret = static::TEST_CONSUMER_SECRET;
+        $request = [
+            'user_id' => '$ANONYMIZED_USER_ID',
+            'rendering_type' => 'assess',
+            'name' => 'Items API demo - assess activity demo',
+            'state' => 'initial',
+            'activity_id' => 'items_assess_demo',
+            'session_id' => 'demo_session_uuid',
+            'type' => 'submit_practice',
+            'config' => [
+                'configuration' => [
+                    'responsive_regions' => true
+                ],
+                'navigation' => [
+                    'scrolling_indicator' => true
+                ],
+                'regions' => 'main',
+                'time' => [
+                    'show_pause' => true,
+                    'max_time' => 300
+                ],
+                'title' => 'ItemsAPI Assess Isolation Demo',
+                'subtitle' => 'Testing Subtitle Text'
+            ],
+            'items' => [
+                'Demo3'
+            ]
+        ];
+        $action = null;
+
+        if ($assoc) {
+            return [
+                'service' => $service,
+                'security' => $security,
+                'secret' => $secret,
+                'request' => $request,
+                'action' => $action,
+            ];
+        } else {
+            return [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action,
+            ];
+        }
+    }
+
+    /**
+     * @param  bool $assoc If true, associative array will be returned
+     * @return array
+     */
+    public static function getWorkingQuestionsApiParams(bool $assoc = false): array
+    {
+        $service = 'questions';
+        $security = static::getSecurity();
+        $security['user_id'] = '$ANONYMIZED_USER_ID';
+        $secret = static::TEST_CONSUMER_SECRET;
+        $request = [
+            'type'      => 'local_practice',
+            'state'     => 'initial',
+            'questions' => [
+                [
+                    'response_id'        => '60005',
+                    'type'               => 'association',
+                    'stimulus'           => 'Match the cities to the parent nation.',
+                    'stimulus_list'      => ['London', 'Dublin', 'Paris', 'Sydney'],
+                    'possible_responses' => ['Australia', 'France', 'Ireland', 'England'],
+                    'validation' => [
+                        'valid_responses' => [
+                            ['England'], ['Ireland'], ['France'], ['Australia']
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $action = null;
+
+        if ($assoc) {
+            return [
+                'service' => $service,
+                'security' => $security,
+                'secret' => $secret,
+                'request' => $request,
+                'action' => $action,
+            ];
+        } else {
+            return [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action,
+            ];
+        }
+    }
+
+    /**
+     * @param  bool $assoc If true, associative array will be returned
+     * @return array
+     */
+    public static function getWorkingReportsApiParams(bool $assoc = false): array
+    {
+        $service = 'reports';
+        $security = static::getSecurity();
+        $secret = static::TEST_CONSUMER_SECRET;
+        $request = [
+           "reports" => [
+               [
+                   "id" => "report-1",
+                   "type" => "sessions-summary",
+                   "user_id" => '$ANONYMIZED_USER_ID',
+                   "session_ids" => [
+                       "AC023456-2C73-44DC-82DA28894FCBC3BF"
+                   ]
+               ]
+           ]
+        ];
+        $action = null;
+
+        if ($assoc) {
+            return [
+                'service' => $service,
+                'security' => $security,
+                'secret' => $secret,
+                'request' => $request,
+                'action' => $action,
+            ];
+        } else {
+            return [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action,
+            ];
+        }
+    }
+
+    /**
+     *
+     * @return array
+     */
+    public static function getMetaField(): array
+    {
+        return [
+            "test_key_string" => "test-string",
+            "test_key_integer" => 12345,
+            "test_key_boolean" => true,
+        ];
+    }
+}

--- a/tests/Fixtures/ParamsFixture.php
+++ b/tests/Fixtures/ParamsFixture.php
@@ -152,6 +152,8 @@ class ParamsFixture
     public static function getAuthorApiSignatureForVersion(string $version): string
     {
         switch ($version) {
+            case '01':
+                return '108b985a4db36ef03905572943a514fc02ed7cc6b700926183df7babc2cd1c96';
             case '02':
                 return '$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861';
             default:
@@ -240,6 +242,8 @@ class ParamsFixture
     public static function getDataApiSignatureForVersion(string $version): string
     {
         switch ($version) {
+            case '01':
+                return 'e1eae0b86148df69173cb3b824275ea73c9c93967f7d17d6957fcdd299c8a4fe';
             case '02':
                 return '$02$e19c8a62fba81ef6baf2731e2ab0512feaf573ca5ca5929c2ee9a77303d2e197';
             default:
@@ -284,6 +288,8 @@ class ParamsFixture
     public static function getEventsApiSignatureForVersion(string $version): string
     {
         switch ($version) {
+            case '01':
+                return '20739eed410d54a135e8cb3745628834886ab315bfc01693ce9acc0d14dc98bf';
             case '02':
                 return '$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349';
             default:
@@ -348,6 +354,8 @@ class ParamsFixture
     public static function getItemsApiSignatureForVersion(string $version): string
     {
         switch ($version) {
+            case '01':
+                return '82edaf80c2abb55c7a78d089f5b6f89393e621ef4a85150489ac2cfdd6a32f9a';
             case '02':
                 return '$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9';
             default:
@@ -403,6 +411,8 @@ class ParamsFixture
     public static function getQuestionsApiSignatureForVersion(string $version): string
     {
         switch ($version) {
+            case '01':
+                return '03f4869659eeaca81077785135d5157874f4800e57752bf507891bf39c4d4a90';
             case '02':
                 return '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8';
             default:
@@ -451,6 +461,8 @@ class ParamsFixture
     public static function getReportsApiSignatureForVersion(string $version): string
     {
         switch ($version) {
+            case '01':
+                return '91085beccf57bf0df77c89df94d1055e631b36bc11941e61460b445b4ed774bc';
             case '02':
                 return '$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84';
             default:

--- a/tests/Fixtures/ParamsFixture.php
+++ b/tests/Fixtures/ParamsFixture.php
@@ -87,24 +87,26 @@ class ParamsFixture
         ];
         $action = null;
 
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
+        $params = [
+            'service' => $service,
+            'security' => $security,
+            'secret' => $secret,
+            'request' => $request,
+            'action' => $action,
+        ];
+
+        if (!$assoc) {
+            return array_values($params);
         }
+
+        return $params;
     }
+
+    public static function getAssessApiSignatureForVersion(string $version): string
+    {
+        return static::getQuestionsApiSignatureForVersion($version);
+    }
+
 
     /**
      * @param  bool $assoc If true, associative array will be returned
@@ -116,38 +118,44 @@ class ParamsFixture
         $security = static::getSecurity();
         $secret = static::TEST_CONSUMER_SECRET;
         $request = [
-            "mode" => "item_list",
-            "config" => [
-                "item_list" => [
-                    "item" => [
-                        "status" => true
-                    ]
+        "mode" => "item_list",
+        "config" => [
+            "item_list" => [
+                "item" => [
+                    "status" => true
                 ]
-            ],
-            "user" => [
-                "id" => "walterwhite",
-                "firstname" => "walter",
-                "lastname" => "white"
             ]
+        ],
+        "user" => [
+            "id" => "walterwhite",
+            "firstname" => "walter",
+            "lastname" => "white"
+        ]
         ];
         $action = null;
 
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
+        $params = [
+            'service' => $service,
+            'security' => $security,
+            'secret' => $secret,
+            'request' => $request,
+            'action' => $action,
+        ];
+
+        if (!$assoc) {
+            return array_values($params);
+        }
+
+        return $params;
+    }
+
+    public static function getAuthorApiSignatureForVersion(string $version): string
+    {
+        switch ($version) {
+            case '02':
+                return '$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861';
+            default:
+                throw new \Exception(__FUNCTION__ . ' not re-implemented for signature version ' . $version);
         }
     }
 
@@ -172,22 +180,28 @@ class ParamsFixture
         ];
         $action = null;
 
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
+        $params = [
+            'service' => $service,
+            'security' => $security,
+            'secret' => $secret,
+            'request' => $request,
+            'action' => $action,
+        ];
+
+        if (!$assoc) {
+            return array_values($params);
+        }
+
+        return $params;
+    }
+
+    public static function getAuthorAideApiSignatureForVersion(string $version): string
+    {
+        switch ($version) {
+            case '02':
+                return '$02$f2ce1da2fdead193d53ab954b8a3660548ed9b0e3ce60599d751130deba7a138';
+            default:
+                throw new \Exception(__FUNCTION__ . ' not re-implemented for signature version ' . $version);
         }
     }
 
@@ -208,22 +222,28 @@ class ParamsFixture
         ];
         $action = 'get';
 
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action
-            ];
+        $params = [
+            'service' => $service,
+            'security' => $security,
+            'secret' => $secret,
+            'request' => $request,
+            'action' => $action,
+        ];
+
+        if (!$assoc) {
+            return array_values($params);
+        }
+
+        return $params;
+    }
+
+    public static function getDataApiSignatureForVersion(string $version): string
+    {
+        switch ($version) {
+            case '02':
+                return '$02$e19c8a62fba81ef6baf2731e2ab0512feaf573ca5ca5929c2ee9a77303d2e197';
+            default:
+                throw new \Exception(__FUNCTION__ . ' not re-implemented for signature version ' . $version);
         }
     }
 
@@ -246,22 +266,28 @@ class ParamsFixture
         ];
         $action = null;
 
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
+        $params = [
+            'service' => $service,
+            'security' => $security,
+            'secret' => $secret,
+            'request' => $request,
+            'action' => $action,
+        ];
+
+        if (!$assoc) {
+            return array_values($params);
+        }
+
+        return $params;
+    }
+
+    public static function getEventsApiSignatureForVersion(string $version): string
+    {
+        switch ($version) {
+            case '02':
+                return '$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349';
+            default:
+                throw new \Exception(__FUNCTION__ . ' not re-implemented for signature version ' . $version);
         }
     }
 
@@ -304,22 +330,28 @@ class ParamsFixture
         ];
         $action = null;
 
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
+        $params = [
+            'service' => $service,
+            'security' => $security,
+            'secret' => $secret,
+            'request' => $request,
+            'action' => $action,
+        ];
+
+        if (!$assoc) {
+            return array_values($params);
+        }
+
+        return $params;
+    }
+
+    public static function getItemsApiSignatureForVersion(string $version): string
+    {
+        switch ($version) {
+            case '02':
+                return '$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9';
+            default:
+                throw new \Exception(__FUNCTION__ . ' not re-implemented for signature version ' . $version);
         }
     }
 
@@ -353,22 +385,28 @@ class ParamsFixture
         ];
         $action = null;
 
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
+        $params = [
+            'service' => $service,
+            'security' => $security,
+            'secret' => $secret,
+            'request' => $request,
+            'action' => $action,
+        ];
+
+        if (!$assoc) {
+            return array_values($params);
+        }
+
+        return $params;
+    }
+
+    public static function getQuestionsApiSignatureForVersion(string $version): string
+    {
+        switch ($version) {
+            case '02':
+                return '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8';
+            default:
+                throw new \Exception(__FUNCTION__ . ' not re-implemented for signature version ' . $version);
         }
     }
 
@@ -395,22 +433,28 @@ class ParamsFixture
         ];
         $action = null;
 
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
+        $params = [
+            'service' => $service,
+            'security' => $security,
+            'secret' => $secret,
+            'request' => $request,
+            'action' => $action,
+        ];
+
+        if (!$assoc) {
+            return array_values($params);
+        }
+
+        return $params;
+    }
+
+    public static function getReportsApiSignatureForVersion(string $version): string
+    {
+        switch ($version) {
+            case '02':
+                return '$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84';
+            default:
+                throw new \Exception(__FUNCTION__ . ' not re-implemented for signature version ' . $version);
         }
     }
 

--- a/tests/Fixtures/ParamsFixture.php
+++ b/tests/Fixtures/ParamsFixture.php
@@ -6,6 +6,14 @@ use LearnositySdk\Services\Signatures\HmacSignature;
 
 // XXX: should be in a Test namespace
 
+/**
+ * Fixture providing example requests for the various APIs. It also provides some well-known signatures using various of
+ * our historical schemes.
+ *
+ * /!\ Please do not modify those requests lightly. They are used to test backward compatibility of the signature modes,
+ * and changing those requests would require changing the expected signatures, based on legacy code that we no longer
+ * have in our codebase. /!\
+ */
 class ParamsFixture
 {
     const TEST_CONSUMER_KEY = 'yis0TYCu7U9V4o7M';

--- a/tests/Request/DataApiTest.php
+++ b/tests/Request/DataApiTest.php
@@ -3,6 +3,7 @@
 namespace LearnositySdk\Request;
 
 use LearnositySdk\AbstractTestCase;
+use LearnositySdk\Fixtures\ParamsFixture;
 
 class DataApiTest extends AbstractTestCase
 {
@@ -12,8 +13,8 @@ class DataApiTest extends AbstractTestCase
     public function testRequest()
     {
         $securityPacket = [
-            'consumer_key' => self::TEST_CONSUMER_KEY,
-            'domain' => self::TEST_DOMAIN,
+            'consumer_key' => ParamsFixture::TEST_CONSUMER_KEY,
+            'domain' => ParamsFixture::TEST_DOMAIN,
         ];
 
         $dataRequest = [
@@ -28,7 +29,7 @@ class DataApiTest extends AbstractTestCase
             $result = $dataApi->request(
                 self::ITEMBANK_ITEMS_URI,
                 $securityPacket,
-                self::TEST_CONSUMER_SECRET,
+                ParamsFixture::TEST_CONSUMER_SECRET,
                 $dataRequest,
                 'get'
             );
@@ -48,7 +49,8 @@ class DataApiTest extends AbstractTestCase
             $this->assertArrayHasKey('records', $response['meta']);
             $this->assertCount($response['meta']['records'], $response['data']);
 
-            if (isset($response['meta']['next'])
+            if (
+                isset($response['meta']['next'])
                 && isset($response['meta']['records'])
                 && $response['meta']['records'] > 0
             ) {
@@ -64,8 +66,8 @@ class DataApiTest extends AbstractTestCase
     public function testRequestRecursive()
     {
         $securityPacket = [
-            'consumer_key' => self::TEST_CONSUMER_KEY,
-            'domain' => self::TEST_DOMAIN,
+            'consumer_key' => ParamsFixture::TEST_CONSUMER_KEY,
+            'domain' => ParamsFixture::TEST_DOMAIN,
         ];
 
         $dataRequest = [
@@ -77,7 +79,7 @@ class DataApiTest extends AbstractTestCase
         $result = $dataApi->requestRecursive(
             self::ITEMBANK_ITEMS_URI,
             $securityPacket,
-            self::TEST_CONSUMER_SECRET,
+            ParamsFixture::TEST_CONSUMER_SECRET,
             $dataRequest,
             'get',
             null,
@@ -92,8 +94,8 @@ class DataApiTest extends AbstractTestCase
     public function testRequestRecursiveCallback()
     {
         $securityPacket = [
-            'consumer_key' => self::TEST_CONSUMER_KEY,
-            'domain' => self::TEST_DOMAIN,
+            'consumer_key' => ParamsFixture::TEST_CONSUMER_KEY,
+            'domain' => ParamsFixture::TEST_DOMAIN,
         ];
 
         $dataRequest = [
@@ -109,7 +111,7 @@ class DataApiTest extends AbstractTestCase
         $dataApi->requestRecursive(
             self::ITEMBANK_ITEMS_URI,
             $securityPacket,
-            self::TEST_CONSUMER_SECRET,
+            ParamsFixture::TEST_CONSUMER_SECRET,
             $dataRequest,
             'get',
             function (array $data) use (&$requestCount, &$results) {
@@ -461,8 +463,8 @@ JSON;
         $expectedResult = json_decode($expectedResult, true);
 
         $securityPacket = [
-            'consumer_key' => self::TEST_CONSUMER_KEY,
-            'domain' => self::TEST_DOMAIN,
+            'consumer_key' => ParamsFixture::TEST_CONSUMER_KEY,
+            'domain' => ParamsFixture::TEST_DOMAIN,
         ];
 
         $dataRequest = [
@@ -477,7 +479,7 @@ JSON;
         $results = $dataApi->requestRecursive(
             self::ITEMBANK_QUESTIONS_URI,
             $securityPacket,
-            self::TEST_CONSUMER_SECRET,
+            ParamsFixture::TEST_CONSUMER_SECRET,
             $dataRequest,
             'get'
         );

--- a/tests/Request/InitTest.php
+++ b/tests/Request/InitTest.php
@@ -2,8 +2,9 @@
 
 namespace LearnositySdk\Request;
 
-use LearnositySdk\AbstractTestCase;
+use LearnositySdk\AbstractTestCase; // XXX: should be in a Test namespace
 use LearnositySdk\Exceptions\ValidationException;
+use LearnositySdk\Fixtures\ParamsFixture; // XXX: should be in a Test namespace
 use LearnositySdk\Services\SignatureFactory;
 
 class InitTest extends AbstractTestCase
@@ -120,35 +121,35 @@ class InitTest extends AbstractTestCase
 
     public function testNullRequestPacketGeneratesValidInit()
     {
-        list($service, $security, $secret) = static::getWorkingDataApiParams();
+        list($service, $security, $secret) = ParamsFixture::getWorkingDataApiParams();
         $initObject = new Init($service, $security, $secret, null, null);
         $this->assertInstanceOf(Init::class, $initObject);
     }
 
     public function testEmptyArrayRequestPacketGeneratesValidInit()
     {
-        list($service, $security, $secret) = static::getWorkingDataApiParams();
+        list($service, $security, $secret) = ParamsFixture::getWorkingDataApiParams();
         $initObject = new Init($service, $security, $secret, [], null);
         $this->assertInstanceOf(Init::class, $initObject);
     }
 
     public function testEmptyStringGeneratesValidInit()
     {
-        list($service, $security, $secret) = static::getWorkingDataApiParams();
+        list($service, $security, $secret) = ParamsFixture::getWorkingDataApiParams();
         $initObject = new Init($service, $security, $secret, "", null);
         $this->assertInstanceOf(Init::class, $initObject);
     }
 
     public function testNullRequestPacketAndActionGeneratesValidInit()
     {
-        list($service, $security, $secret) = static::getWorkingDataApiParams();
+        list($service, $security, $secret) = ParamsFixture::getWorkingDataApiParams();
         $initObject = new Init($service, $security, $secret, null, null);
         $this->assertInstanceOf(Init::class, $initObject);
     }
 
     public function testMetaWithTelemetryOnlyAddsSdkProp()
     {
-        list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
 
         // This test verifies the correctness of the added telemetry data
         Init::enableTelemetry();
@@ -165,10 +166,10 @@ class InitTest extends AbstractTestCase
 
     public function testRequestWithTelemetryPreservesOtherMetaProps()
     {
-        list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
 
         // add meta field to the $request
-        $request['meta'] = $this->getMetaField();
+        $request['meta'] = ParamsFixture::getMetaField();
 
         // generate a new $initObject using the updated $request
         $initObject = new Init($service, $security, $secret, json_encode($request), $action);
@@ -191,7 +192,7 @@ class InitTest extends AbstractTestCase
     public function testRequestWithoutTelemetryPreservesEmptyMeta()
     {
         Init::disableTelemetry();
-        list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
 
         $initObject = new Init($service, $security, $secret, json_encode($request), $action);
         $generatedObject = json_decode($initObject->generate());
@@ -204,10 +205,10 @@ class InitTest extends AbstractTestCase
     public function testRequestWithoutTelemetryPreservesFilledMeta()
     {
         Init::disableTelemetry();
-        list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
 
         // add meta field to the $request
-        $request['meta'] = $this->getMetaField();
+        $request['meta'] = ParamsFixture::getMetaField();
 
         $initObject = new Init($service, $security, $secret, json_encode($request), $action);
         $generatedObject = json_decode($initObject->generate());
@@ -227,445 +228,12 @@ class InitTest extends AbstractTestCase
     }
 
     /*
-     * Pseudo fixtures for parameters
-     */
-
-    /**
-     * @param  bool $assoc If true, associative array will be returned
-     * @return array
-     */
-    public static function getWorkingAssessApiParams(bool $assoc = false): array
-    {
-        $service = 'assess';
-        $security = static::getSecurity();
-        // Needed to initialise Questions API
-        $security['user_id'] = '$ANONYMIZED_USER_ID';
-        $secret = static::TEST_CONSUMER_SECRET;
-        $request = [
-            "items" => [
-                [
-                    "content" => '<span class="learnosity-response question-demoscience1234"></span>',
-                    "response_ids" => [
-                        "demoscience1234"
-                    ],
-                    "workflow" => "",
-                    "reference" => "question-demoscience1"
-                ],
-                [
-                    "content" => '<span class="learnosity-response question-demoscience5678"></span>',
-                    "response_ids" => [
-                        "demoscience5678"
-                    ],
-                    "workflow" => "",
-                    "reference" => "question-demoscience2"
-                ]
-            ],
-            "ui_style" => "horizontal",
-            "name" => "Demo (2 questions)",
-            "state" => "initial",
-            "metadata" => [],
-            "navigation" => [
-                "show_next" => true,
-                "toc" => true,
-                "show_submit" => true,
-                "show_save" => false,
-                "show_prev" => true,
-                "show_title" => true,
-                "show_intro" => true,
-            ],
-            "time" => [
-                "max_time" => 600,
-                "limit_type" => "soft",
-                "show_pause" => true,
-                "warning_time" => 60,
-                "show_time" => true
-            ],
-            "configuration" => [
-                "onsubmit_redirect_url" => "/assessment/",
-                "onsave_redirect_url" => "/assessment/",
-                "idle_timeout" => true,
-                "questionsApiVersion" => "v2"
-            ],
-            "questionsApiActivity" => [
-                "user_id" => '$ANONYMIZED_USER_ID',
-                "type" => "submit_practice",
-                "state" => "initial",
-                "id" => "assessdemo",
-                "name" => "Assess API - Demo",
-                "questions" => [
-                    [
-                        "response_id" => "demoscience1234",
-                        "type" => "sortlist",
-                        "description" => "In this question, the student needs to sort the events, chronologically earliest to latest.",
-                        "list" => ["Russian Revolution", "Discovery of the Americas", "Storming of the Bastille", "Battle of Plataea", "Founding of Rome", "First Crusade"],
-                        "instant_feedback" => true,
-                        "feedback_attempts" => 2,
-                        "validation" => [
-                            "valid_response" => [4, 3, 5, 1, 2, 0],
-                            "valid_score" => 1,
-                            "partial_scoring" => true,
-                            "penalty_score" => -1
-                        ]
-                    ],
-                    [
-                        "response_id" => "demoscience5678",
-                        "type" => "highlight",
-                        "description" => "The student needs to mark one of the flowers anthers in the image.",
-                        "img_src" => "http://www.learnosity.com/static/img/flower.jpg",
-                        "line_color" => "rgb(255, 20, 0)",
-                        "line_width" => "4"
-                    ]
-                ]
-            ],
-            "type" => "activity"
-        ];
-        $action = null;
-
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
-        }
-    }
-
-    /**
-     * @param  bool $assoc If true, associative array will be returned
-     * @return array
-     */
-    public static function getWorkingAuthorApiParams(bool $assoc = false): array
-    {
-        $service = 'author';
-        $security = static::getSecurity();
-        $secret = static::TEST_CONSUMER_SECRET;
-        $request = [
-            "mode" => "item_list",
-            "config" => [
-                "item_list" => [
-                    "item" => [
-                        "status" => true
-                    ]
-                ]
-            ],
-            "user" => [
-                "id" => "walterwhite",
-                "firstname" => "walter",
-                "lastname" => "white"
-            ]
-        ];
-        $action = null;
-
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
-        }
-    }
-
-    /**
-     * @param  bool $assoc If true, associative array will be returned
-     * @return array
-     */
-    public static function getWorkingAuthorAideApiParams(bool $assoc = false): array
-    {
-        $service = 'authoraide';
-        $security = static::getSecurity();
-        $secret = static::TEST_CONSUMER_SECRET;
-        $request = [
-            "config" => [
-                "test-attribute" => "test"
-            ],
-            "user" => [
-                "id" => "walterwhite",
-                "firstname" => "walter",
-                "lastname" => "white"
-            ]
-        ];
-        $action = null;
-
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
-        }
-    }
-
-    /**
-     * WARNING: RemoteTest is also using this params
-     *
-     * @param  bool $assoc If true, associative array will be returned
-     * @return array
-     */
-    public static function getWorkingDataApiParams(bool $assoc = false): array
-    {
-        $service = 'data';
-        $security = static::getSecurity();
-        $secret = static::TEST_CONSUMER_SECRET;
-        $request = [
-            'limit' => 100,
-        ];
-        $action = 'get';
-
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action
-            ];
-        }
-    }
-
-    /**
-     * @param  bool $assoc If true, associative array will be returned
-     * @return array
-     */
-    public static function getWorkingEventsApiParams(bool $assoc = false): array
-    {
-        $service = 'events';
-        $security = static::getSecurity();
-        $secret = static::TEST_CONSUMER_SECRET;
-        $request = [
-            'users' => [
-                '$ANONYMIZED_USER_ID_1' => '$ANONYMIZED_USER_ID_1_NAME',
-                '$ANONYMIZED_USER_ID_2' => '$ANONYMIZED_USER_ID_2_NAME',
-                '$ANONYMIZED_USER_ID_3' => '$ANONYMIZED_USER_ID_3_NAME',
-                '$ANONYMIZED_USER_ID_4' => '$ANONYMIZED_USER_ID_4_NAME'
-            ]
-        ];
-        $action = null;
-
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
-        }
-    }
-
-    /**
-     * @param  bool $assoc If true, associative array will be returned
-     * @return array
-     */
-    public static function getWorkingItemsApiParams(bool $assoc = false): array
-    {
-        $service = 'items';
-        $security = static::getSecurity();
-        $secret = static::TEST_CONSUMER_SECRET;
-        $request = [
-            'user_id' => '$ANONYMIZED_USER_ID',
-            'rendering_type' => 'assess',
-            'name' => 'Items API demo - assess activity demo',
-            'state' => 'initial',
-            'activity_id' => 'items_assess_demo',
-            'session_id' => 'demo_session_uuid',
-            'type' => 'submit_practice',
-            'config' => [
-                'configuration' => [
-                    'responsive_regions' => true
-                ],
-                'navigation' => [
-                    'scrolling_indicator' => true
-                ],
-                'regions' => 'main',
-                'time' => [
-                    'show_pause' => true,
-                    'max_time' => 300
-                ],
-                'title' => 'ItemsAPI Assess Isolation Demo',
-                'subtitle' => 'Testing Subtitle Text'
-            ],
-            'items' => [
-                'Demo3'
-            ]
-        ];
-        $action = null;
-
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
-        }
-    }
-
-    /**
-     * @param  bool $assoc If true, associative array will be returned
-     * @return array
-     */
-    public static function getWorkingQuestionsApiParams(bool $assoc = false): array
-    {
-        $service = 'questions';
-        $security = static::getSecurity();
-        $security['user_id'] = '$ANONYMIZED_USER_ID';
-        $secret = static::TEST_CONSUMER_SECRET;
-        $request = [
-            'type'      => 'local_practice',
-            'state'     => 'initial',
-            'questions' => [
-                [
-                    'response_id'        => '60005',
-                    'type'               => 'association',
-                    'stimulus'           => 'Match the cities to the parent nation.',
-                    'stimulus_list'      => ['London', 'Dublin', 'Paris', 'Sydney'],
-                    'possible_responses' => ['Australia', 'France', 'Ireland', 'England'],
-                    'validation' => [
-                        'valid_responses' => [
-                            ['England'], ['Ireland'], ['France'], ['Australia']
-                        ]
-                    ]
-                ]
-            ]
-        ];
-        $action = null;
-
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
-        }
-    }
-
-    /**
-     * @param  bool $assoc If true, associative array will be returned
-     * @return array
-     */
-    public static function getWorkingReportsApiParams(bool $assoc = false): array
-    {
-        $service = 'reports';
-        $security = static::getSecurity();
-        $secret = static::TEST_CONSUMER_SECRET;
-        $request = [
-            "reports" => [
-                [
-                    "id" => "report-1",
-                    "type" => "sessions-summary",
-                    "user_id" => '$ANONYMIZED_USER_ID',
-                    "session_ids" => [
-                        "AC023456-2C73-44DC-82DA28894FCBC3BF"
-                    ]
-                ]
-            ]
-        ];
-        $action = null;
-
-        if ($assoc) {
-            return [
-                'service' => $service,
-                'security' => $security,
-                'secret' => $secret,
-                'request' => $request,
-                'action' => $action,
-            ];
-        } else {
-            return [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-            ];
-        }
-    }
-
-    /**
-     *
-     * @return array
-     */
-    public function getMetaField(): array
-    {
-        return [
-            "test_key_string" => "test-string",
-            "test_key_integer" => 12345,
-            "test_key_boolean" => true,
-        ];
-    }
-
-    /*
      * Data providers
      */
 
     public function constructorProvider(): array
     {
-        list($service, $security, $secret, $request, $action) = static::getWorkingDataApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
 
         $wrongSecurity = $security;
         $wrongSecurity['wrongParam'] = '';
@@ -697,7 +265,7 @@ class InitTest extends AbstractTestCase
         $testCases = [];
 
         /* Author */
-        list($service, $security, $secret, $request, $action) = static::getWorkingAuthorApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorApiParams();
         $authorApi = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861"},"request":{"mode":"item_list","config":{"item_list":{"item":{"status":true}}},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}}',
             $service, $security, $secret, $request, $action,
@@ -705,7 +273,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-author'] = $authorApi;
 
         /* Author Aide */
-        list($service, $security, $secret, $request, $action) = static::getWorkingAuthorAideApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorAideApiParams();
         $authorAideApi = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$f2ce1da2fdead193d53ab954b8a3660548ed9b0e3ce60599d751130deba7a138"},"request":{"config":{"test-attribute":"test"},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}}',
             $service, $security, $secret, $request, $action,
@@ -713,7 +281,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-authoraide'] = $authorAideApi;
 
         /* Assess */
-        list($service, $security, $secret, $request, $action) = static::getWorkingAssessApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAssessApiParams();
         $assessApi = [
             '{"items":[{"content":"<span class=\"learnosity-response question-demoscience1234\"></span>","response_ids":["demoscience1234"],"workflow":"","reference":"question-demoscience1"},{"content":"<span class=\"learnosity-response question-demoscience5678\"></span>","response_ids":["demoscience5678"],"workflow":"","reference":"question-demoscience2"}],"ui_style":"horizontal","name":"Demo (2 questions)","state":"initial","metadata":[],"navigation":{"show_next":true,"toc":true,"show_submit":true,"show_save":false,"show_prev":true,"show_title":true,"show_intro":true},"time":{"max_time":600,"limit_type":"soft","show_pause":true,"warning_time":60,"show_time":true},"configuration":{"onsubmit_redirect_url":"/assessment/","onsave_redirect_url":"/assessment/","idle_timeout":true,"questionsApiVersion":"v2"},"questionsApiActivity":{"user_id":"$ANONYMIZED_USER_ID","type":"submit_practice","state":"initial","id":"assessdemo","name":"Assess API - Demo","questions":[{"response_id":"demoscience1234","type":"sortlist","description":"In this question, the student needs to sort the events, chronologically earliest to latest.","list":["Russian Revolution","Discovery of the Americas","Storming of the Bastille","Battle of Plataea","Founding of Rome","First Crusade"],"instant_feedback":true,"feedback_attempts":2,"validation":{"valid_response":[4,3,5,1,2,0],"valid_score":1,"partial_scoring":true,"penalty_score":-1}},{"response_id":"demoscience5678","type":"highlight","description":"The student needs to mark one of the flowers anthers in the image.","img_src":"http://www.learnosity.com/static/img/flower.jpg","line_color":"rgb(255, 20, 0)","line_width":"4"}],"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8"},"type":"activity"}',
             $service, $security, $secret, $request, $action,
@@ -721,7 +289,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-assess'] = $assessApi;
 
         /* Data */
-        list($service, $security, $secret, $request, $action) = static::getWorkingDataApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
         $security['timestamp'] = '20140626-0528';
         $dataApiGet = [
             [
@@ -744,7 +312,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-data_post'] = $dataApiPost;
 
         /* Events */
-        list($service, $security, $secret, $request, $action) = static::getWorkingEventsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingEventsApiParams();
         $eventsApiExpected = '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349"},"config":{"users":{"$ANONYMIZED_USER_ID_1":"64ccf06154cf4133624372459ebcccb8b2f8bd7458a73df681acef4e742e175c","$ANONYMIZED_USER_ID_2":"7fa4d6ef8926add8b6411123fce916367250a6a99f50ab8ec39c99d768377adb","$ANONYMIZED_USER_ID_3":"3d5b26843da9192319036b67f8c5cc26e1e1763811270ba164665d0027296952","$ANONYMIZED_USER_ID_4":"3b6ac78f60f3e3eb7a85cec8b48bdca0f590f959e0a87a9c4222898678bd50c8"}}}';
         $eventsApi = [
             $eventsApiExpected,
@@ -753,7 +321,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-events'] = $eventsApi;
 
         /* Items */
-        list($service, $security, $secret, $request, $action) = static::getWorkingItemsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingItemsApiParams();
         $itemsApi = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9"},"request":{"user_id":"$ANONYMIZED_USER_ID","rendering_type":"assess","name":"Items API demo - assess activity demo","state":"initial","activity_id":"items_assess_demo","session_id":"demo_session_uuid","type":"submit_practice","config":{"configuration":{"responsive_regions":true},"navigation":{"scrolling_indicator":true},"regions":"main","time":{"show_pause":true,"max_time":300},"title":"ItemsAPI Assess Isolation Demo","subtitle":"Testing Subtitle Text"},"items":["Demo3"]}}',
             $service, $security, $secret, $request, $action,
@@ -761,7 +329,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-items'] = $itemsApi;
 
         /* Questions */
-        list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
         $questionsApi = [
             '{"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8","type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}]}',
             $service, $security, $secret, $request, $action,
@@ -769,7 +337,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-questions'] = $questionsApi;
 
         /* Reports */
-        list($service, $security, $secret, $request, $action) = static::getWorkingReportsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingReportsApiParams();
         $reportsApi = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84"},"request":{"reports":[{"id":"report-1","type":"sessions-summary","user_id":"$ANONYMIZED_USER_ID","session_ids":["AC023456-2C73-44DC-82DA28894FCBC3BF"]}]}}',
             $service, $security, $secret, $request, $action,
@@ -777,14 +345,14 @@ class InitTest extends AbstractTestCase
         $testCases['api-reports'] = $reportsApi;
 
         /* Passing request as string */
-        list($service, $security, $secret, $request, $action) = static::getWorkingAuthorApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorApiParams();
         $authorApiAsString = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861"},"request":"{\"mode\":\"item_list\",\"config\":{\"item_list\":{\"item\":{\"status\":true}}},\"user\":{\"id\":\"walterwhite\",\"firstname\":\"walter\",\"lastname\":\"white\"}}"}',
             $service, $security, $secret, json_encode($request), $action,
         ];
         $testCases['api-author_string'] = $authorApiAsString;
 
-        list($service, $security, $secret, $request, $action) = static::getWorkingAuthorAideApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorAideApiParams();
         $authorAideApiAsString = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$f2ce1da2fdead193d53ab954b8a3660548ed9b0e3ce60599d751130deba7a138"},"request":"{\"config\":{\"test-attribute\":\"test\"},\"user\":{\"id\":\"walterwhite\",\"firstname\":\"walter\",\"lastname\":\"white\"}}"}',
             $service, $security, $secret, json_encode($request), $action,
@@ -792,7 +360,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-authoraide_string'] = $authorAideApiAsString;
 
         /* Items */
-        list($service, $security, $secret, $request, $action) = static::getWorkingItemsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingItemsApiParams();
         $itemsApiAsString = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9"},"request":"{\"user_id\":\"$ANONYMIZED_USER_ID\",\"rendering_type\":\"assess\",\"name\":\"Items API demo - assess activity demo\",\"state\":\"initial\",\"activity_id\":\"items_assess_demo\",\"session_id\":\"demo_session_uuid\",\"type\":\"submit_practice\",\"config\":{\"configuration\":{\"responsive_regions\":true},\"navigation\":{\"scrolling_indicator\":true},\"regions\":\"main\",\"time\":{\"show_pause\":true,\"max_time\":300},\"title\":\"ItemsAPI Assess Isolation Demo\",\"subtitle\":\"Testing Subtitle Text\"},\"items\":[\"Demo3\"]}"}',
             $service, $security, $secret, json_encode($request), $action,
@@ -817,7 +385,7 @@ class InitTest extends AbstractTestCase
         $testCases = [];
 
         /* Author */
-        list($service, $security, $secret, $request, $action) = static::getWorkingAuthorApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorApiParams();
         $authorApi = [
             '$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861',
             $service, $security, $secret, $request, $action,
@@ -825,7 +393,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-author'] = $authorApi;
 
         /* Assess */
-        list($service, $security, $secret, $request, $action) = static::getWorkingAssessApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAssessApiParams();
         $assessApi = [
             '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8',
             $service, $security, $secret, $request, $action,
@@ -833,7 +401,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-assess'] = $assessApi;
 
         /* Data */
-        list($service, $security, $secret, $request, $action) = static::getWorkingDataApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
         $securityExpires = $security;
         $securityExpires['expires'] = '20160621-1716';
 
@@ -856,7 +424,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-data_expire'] = $dataApiExpire;
 
         /* Events */
-        list($service, $security, $secret, $request, $action) = static::getWorkingEventsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingEventsApiParams();
         $eventsApi = [
             '$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349',
             $service, $security, $secret, $request, $action,
@@ -864,7 +432,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-events'] = $eventsApi;
 
         /* Items */
-        list($service, $security, $secret, $request, $action) = static::getWorkingItemsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingItemsApiParams();
         $itemsApi = [
             '$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9',
             $service, $security, $secret, $request, $action,
@@ -872,7 +440,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-items'] = $itemsApi;
 
         /* Questions */
-        list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
         $questionsApi = [
             '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8',
             $service, $security, $secret, $request, $action,
@@ -880,7 +448,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-questions'] = $questionsApi;
 
         /* Reports */
-        list($service, $security, $secret, $request, $action) = static::getWorkingReportsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingReportsApiParams();
         $reportsApi = [
             '$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84',
             $service, $security, $secret, $request, $action,
@@ -903,7 +471,7 @@ class InitTest extends AbstractTestCase
         $testCases = [];
 
         /* Author */
-        list($service, $security, $secret, $request, $action) = static::getWorkingAuthorApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorApiParams();
         $authorApi = [
             'request.meta',
             $service, $security, $secret, $request, $action,
@@ -911,7 +479,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-author'] = $authorApi;
 
         /* Author Aide */
-        list($service, $security, $secret, $request, $action) = static::getWorkingAuthorAideApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorAideApiParams();
         $authorAideApi = [
             'request.meta',
             $service, $security, $secret, $request, $action,
@@ -919,7 +487,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-authoraide'] = $authorAideApi;
 
         /* Assess */
-        list($service, $security, $secret, $request, $action) = static::getWorkingAssessApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAssessApiParams();
         $assessApi = [
             'meta',
             $service, $security, $secret, $request, $action,
@@ -927,7 +495,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-assess'] = $assessApi;
 
         /* Data */
-        list($service, $security, $secret, $request, $action) = static::getWorkingDataApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
         $dataApi = [
             'request.meta',
             $service, $security, $secret, $request, $action,
@@ -935,7 +503,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-data'] = $dataApi;
 
         /* Events */
-        list($service, $security, $secret, $request, $action) = static::getWorkingEventsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingEventsApiParams();
         $eventsApi = [
             'config.meta',
             $service, $security, $secret, $request, $action,
@@ -943,7 +511,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-events'] = $eventsApi;
 
         /* Items */
-        list($service, $security, $secret, $request, $action) = static::getWorkingItemsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingItemsApiParams();
         $itemsApi = [
             'request.meta',
             $service, $security, $secret, $request, $action,
@@ -951,7 +519,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-items'] = $itemsApi;
 
         /* Questions */
-        list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
         $questionsApi = [
             'meta',
             $service, $security, $secret, $request, $action,
@@ -959,7 +527,7 @@ class InitTest extends AbstractTestCase
         $testCases['api-questions'] = $questionsApi;
 
         /* Reports */
-        list($service, $security, $secret, $request, $action) = static::getWorkingReportsApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingReportsApiParams();
         $reportsApi = [
             'request.meta',
             $service, $security, $secret, $request, $action,

--- a/tests/Request/InitTest.php
+++ b/tests/Request/InitTest.php
@@ -434,18 +434,17 @@ class InitTest extends AbstractTestCase
         ];
         $testCases['api-data_get'] = $dataApiGet;
 
-        $dataApiPost = [
+        $dataApiSet = [
             [
                 'security' =>
                     '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"'
-                    . '$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16"}',
+                    . '$02$d9d0406c92100fff171233a3846d3e2d4ee9b27319a2db5f854909996328437a"}',
                 'request'  => '{"limit":100}',
-                'action'   => 'post'
+                'action'   => 'set',
             ],
-            $service, $security, $secret, $request, 'post',
+            $service, $security, $secret, $request, 'set',
         ];
-        // XXX: post is not a valid action; should be set
-        $testCases['api-data_post'] = $dataApiPost;
+        $testCases['api-data_set'] = $dataApiSet;
 
         /* Events */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingEventsApiParams();
@@ -538,12 +537,11 @@ class InitTest extends AbstractTestCase
         $testCases['api-data'] = $dataApi;
 
         /* Events */
-        $dataApiPost = [
-        '$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16',
-        $service, $security, $secret, $request, 'post',
+        $dataApiSet = [
+            '$02$d9d0406c92100fff171233a3846d3e2d4ee9b27319a2db5f854909996328437a',
+            $service, $security, $secret, $request, 'set',
         ];
-        // XXX: post is not a valid action; should be set
-        $testCases['api-data_post'] = $dataApiPost;
+        $testCases['api-data_set'] = $dataApiSet;
 
         $securityExpires = $security;
         $securityExpires['expires'] = '20160621-1716';

--- a/tests/Request/InitTest.php
+++ b/tests/Request/InitTest.php
@@ -253,35 +253,35 @@ class InitTest extends AbstractTestCase
         $wrongSecurity['wrongParam'] = '';
 
         return [
-        'valid-api-data' => [
-            $service,
-            $security,
-            $secret,
-            $request,
-            $action,
-            new Init($service, $security, $secret, $request, $action)
-        ],
-        'empty-service' => [
-            '',
-            $security,
-            $secret,
-            $request,
-            $action,
-            null,
-            ValidationException::class,
-            'The `service` argument wasn\'t found or was empty'
-        ],
-        'invalid-service' => [
-            'wrongService',
-            $security,
-            $secret,
-            $request,
-            $action,
-            null,
-            ValidationException::class,
-            'The service provided (wrongService) is not valid'
-        ],
-        'empty-security' => [
+            'valid-api-data' => [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action,
+                new Init($service, $security, $secret, $request, $action)
+            ],
+            'empty-service' => [
+                '',
+                $security,
+                $secret,
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'The `service` argument wasn\'t found or was empty'
+            ],
+            'invalid-service' => [
+                'wrongService',
+                $security,
+                $secret,
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'The service provided (wrongservice) is not valid'
+            ],
+            'empty-security' => [
 
             $service,
             '',

--- a/tests/Request/InitTest.php
+++ b/tests/Request/InitTest.php
@@ -8,16 +8,10 @@ use LearnositySdk\Services\SignatureFactory;
 
 class InitTest extends AbstractTestCase
 {
-
     /**
      * @var \LearnositySdk\Services\SignatureFactory
      */
     private $signatureFactory;
-
-    public function setUp(): void
-    {
-        $this->signatureFactory = new SignatureFactory();
-    }
 
     /*
      * Tests
@@ -41,7 +35,7 @@ class InitTest extends AbstractTestCase
             $this->expectExceptionMessage($expectedExceptionMessage);
         }
 
-        $init = new Init($service, $securityPacket, $secret, $requestPacket, $action, $this->signatureFactory);
+        $init = new Init($service, $securityPacket, $secret, $requestPacket, $action);
 
         $this->assertEquals($expectedResult, $init);
     }
@@ -49,8 +43,19 @@ class InitTest extends AbstractTestCase
     /**
      * @dataProvider generateWithMetaProvider
      */
-    public function testGenerateWithMeta(string $pathToMeta, $generated)
-    {
+    public function testGenerateWithMeta(
+        string $pathToMeta,
+        string $service,
+        array $security,
+        string $secret,
+        array|string $request,
+        ?string $action
+    ) {
+        // This test verifies the correctness of the added telemetry data
+        Init::enableTelemetry();
+        $initObject = new Init($service, $security, $secret, $request, $action);
+        $generated = $initObject->generate();
+
         $pathParts = explode('.', $pathToMeta);
         // in case of Author API, Assess API, Events API, Items API, Questions API and Reports API
         // generated value is a string, and therefore needs to be decoded
@@ -68,54 +73,76 @@ class InitTest extends AbstractTestCase
     /**
      * @dataProvider generateSignatureProvider
      */
-    public function testGenerateSignature(string $expectedResult, Init $initObject)
-    {
-        $this->assertEquals($expectedResult, $initObject->generateSignature());
+    public function testGenerateSignature(
+        string $expectedSignature,
+        string $service,
+        array $security,
+        string $secret,
+        array|string $request,
+        ?string $action
+    ) {
+        // We disable telemetry to be able to reliably test signature generation. Added telemetry
+        // will differ on each platform tests would be run, and therefore fail.
+        Init::disableTelemetry();
+        $initObject = new Init($service, $security, $secret, $request, $action);
+
+        $this->assertEquals($expectedSignature, $initObject->generateSignature());
     }
 
     /**
      * @dataProvider generateProvider
      */
-    public function testGenerate($expectedResult, Init $initObject)
-    {
+    public function testGenerate(
+        array|string $expectedInitOptions,
+        string $service,
+        array $security,
+        string $secret,
+        array|string $request,
+        ?string $action
+    ) {
+        // We disable telemetry to be able to reliably test signature generation. Added telemetry
+        // will differ on each platform tests would be run, and therefore fail.
+        Init::disableTelemetry();
+
+        $initObject = new Init($service, $security, $secret, $request, $action);
         $generated = $initObject->generate();
 
-        if (is_array($expectedResult)) {
-            ksort($expectedResult);
+        if (is_array($expectedInitOptions)) {
+            ksort($expectedInitOptions);
         }
 
         if (is_array($generated)) {
             ksort($generated);
         }
 
-        $this->assertEquals($expectedResult, $generated);
+        $this->assertEquals($expectedInitOptions, $generated);
     }
 
     public function testNullRequestPacketGeneratesValidInit()
     {
         list($service, $security, $secret) = static::getWorkingDataApiParams();
-        $initObject = new Init($service, $security, $secret, null, null, $this->signatureFactory);
+        $initObject = new Init($service, $security, $secret, null, null);
         $this->assertInstanceOf(Init::class, $initObject);
     }
 
     public function testEmptyArrayRequestPacketGeneratesValidInit()
     {
         list($service, $security, $secret) = static::getWorkingDataApiParams();
-        $initObject = new Init($service, $security, $secret, [], null, $this->signatureFactory);
+        $initObject = new Init($service, $security, $secret, [], null);
         $this->assertInstanceOf(Init::class, $initObject);
     }
 
     public function testEmptyStringGeneratesValidInit()
     {
         list($service, $security, $secret) = static::getWorkingDataApiParams();
-        $initObject = new Init($service, $security, $secret, "", null, $this->signatureFactory);
+        $initObject = new Init($service, $security, $secret, "", null);
         $this->assertInstanceOf(Init::class, $initObject);
     }
 
     public function testNullRequestPacketAndActionGeneratesValidInit()
     {
         list($service, $security, $secret) = static::getWorkingDataApiParams();
-        $initObject = new Init($service, $security, $secret, null, null, $this->signatureFactory);
+        $initObject = new Init($service, $security, $secret, null, null);
         $this->assertInstanceOf(Init::class, $initObject);
     }
 
@@ -123,7 +150,10 @@ class InitTest extends AbstractTestCase
     {
         list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
 
-        $initObject = new Init($service, $security, $secret, json_encode($request), $action, $this->signatureFactory);
+        // This test verifies the correctness of the added telemetry data
+        Init::enableTelemetry();
+
+        $initObject = new Init($service, $security, $secret, json_encode($request), $action);
         $generatedObject = json_decode($initObject->generate());
 
         // when telemetry is enabled, if the $request has no meta field,
@@ -141,7 +171,7 @@ class InitTest extends AbstractTestCase
         $request['meta'] = $this->getMetaField();
 
         // generate a new $initObject using the updated $request
-        $initObject = new Init($service, $security, $secret, json_encode($request), $action, $this->signatureFactory);
+        $initObject = new Init($service, $security, $secret, json_encode($request), $action);
         $generatedObject = json_decode($initObject->generate());
 
         // when telemetry is enabled, if the request has a meta field,
@@ -163,13 +193,12 @@ class InitTest extends AbstractTestCase
         Init::disableTelemetry();
         list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
 
-        $initObject = new Init($service, $security, $secret, json_encode($request), $action, $this->signatureFactory);
+        $initObject = new Init($service, $security, $secret, json_encode($request), $action);
         $generatedObject = json_decode($initObject->generate());
 
         // when telemetry is disabled, if the meta field of the $request is empty,
         // then the meta of the generated object should also be empty
         $this->assertObjectNotHasProperty('meta', $generatedObject);
-        Init::enableTelemetry();
     }
 
     public function testRequestWithoutTelemetryPreservesFilledMeta()
@@ -180,7 +209,7 @@ class InitTest extends AbstractTestCase
         // add meta field to the $request
         $request['meta'] = $this->getMetaField();
 
-        $initObject = new Init($service, $security, $secret, json_encode($request), $action, $this->signatureFactory);
+        $initObject = new Init($service, $security, $secret, json_encode($request), $action);
         $generatedObject = json_decode($initObject->generate());
 
         // when telemetry is disabled, if the meta field of the $request has properties,
@@ -231,7 +260,7 @@ class InitTest extends AbstractTestCase
                     "reference" => "question-demoscience2"
                 ]
             ],
-            "ui_style" =>"horizontal",
+            "ui_style" => "horizontal",
             "name" => "Demo (2 questions)",
             "state" => "initial",
             "metadata" => [],
@@ -585,16 +614,16 @@ class InitTest extends AbstractTestCase
         $security = static::getSecurity();
         $secret = static::TEST_CONSUMER_SECRET;
         $request = [
-           "reports" => [
-               [
-                   "id" => "report-1",
-                   "type" => "sessions-summary",
-                   "user_id" => '$ANONYMIZED_USER_ID',
-                   "session_ids" => [
-                       "AC023456-2C73-44DC-82DA28894FCBC3BF"
-                   ]
-               ]
-           ]
+            "reports" => [
+                [
+                    "id" => "report-1",
+                    "type" => "sessions-summary",
+                    "user_id" => '$ANONYMIZED_USER_ID',
+                    "session_ids" => [
+                        "AC023456-2C73-44DC-82DA28894FCBC3BF"
+                    ]
+                ]
+            ]
         ];
         $action = null;
 
@@ -642,7 +671,7 @@ class InitTest extends AbstractTestCase
         $wrongSecurity['wrongParam'] = '';
 
         return [
-            [$service, $security, $secret, $request, $action, new Init($service, $security, $secret, $request, $action, $this->signatureFactory)],
+            [$service, $security, $secret, $request, $action, new Init($service, $security, $secret, $request, $action)],
             ['', $security, $secret, $request, $action, null, ValidationException::class, 'The `service` argument wasn\'t found or was empty'],
             ['wrongService', $security, $secret, $request, $action, null, ValidationException::class, 'The service provided (wrongService) is not valid'],
             [$service, '', $secret, $request, $action, null, ValidationException::class, 'The security packet must be an array or a valid JSON string'],
@@ -655,403 +684,287 @@ class InitTest extends AbstractTestCase
         ];
     }
 
+    /** @return array:
+     *  - string $expectedSignedInitOptions
+     *  - string $service
+     *  - array $security
+     *  - string $secret
+     *  - array|string $request
+     *  - ?string $action
+     */
     public function generateProvider(): array
     {
-        // We disable telemetry to be able to reliably test signature generation. Added telemetry
-        // will differ on each platform tests would be run, and therefore fail.
-        Init::disableTelemetry();
-
         $testCases = [];
 
         /* Author */
         list($service, $security, $secret, $request, $action) = static::getWorkingAuthorApiParams();
-        $authorApiV1 = [
+        $authorApi = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861"},"request":{"mode":"item_list","config":{"item_list":{"item":{"status":true}}},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $authorApiV1;
+        $testCases['api-author'] = $authorApi;
 
-        $authorApiV2 = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861"},"request":{"mode":"item_list","config":{"item_list":{"item":{"status":true}}},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $authorApiV2;
-
+        /* Author Aide */
         list($service, $security, $secret, $request, $action) = static::getWorkingAuthorAideApiParams();
-        $authorAide = [
+        $authorAideApi = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$f2ce1da2fdead193d53ab954b8a3660548ed9b0e3ce60599d751130deba7a138"},"request":{"config":{"test-attribute":"test"},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $authorAide;
+        $testCases['api-authoraide'] = $authorAideApi;
 
         /* Assess */
         list($service, $security, $secret, $request, $action) = static::getWorkingAssessApiParams();
-        $assessApiV1 = [
+        $assessApi = [
             '{"items":[{"content":"<span class=\"learnosity-response question-demoscience1234\"></span>","response_ids":["demoscience1234"],"workflow":"","reference":"question-demoscience1"},{"content":"<span class=\"learnosity-response question-demoscience5678\"></span>","response_ids":["demoscience5678"],"workflow":"","reference":"question-demoscience2"}],"ui_style":"horizontal","name":"Demo (2 questions)","state":"initial","metadata":[],"navigation":{"show_next":true,"toc":true,"show_submit":true,"show_save":false,"show_prev":true,"show_title":true,"show_intro":true},"time":{"max_time":600,"limit_type":"soft","show_pause":true,"warning_time":60,"show_time":true},"configuration":{"onsubmit_redirect_url":"/assessment/","onsave_redirect_url":"/assessment/","idle_timeout":true,"questionsApiVersion":"v2"},"questionsApiActivity":{"user_id":"$ANONYMIZED_USER_ID","type":"submit_practice","state":"initial","id":"assessdemo","name":"Assess API - Demo","questions":[{"response_id":"demoscience1234","type":"sortlist","description":"In this question, the student needs to sort the events, chronologically earliest to latest.","list":["Russian Revolution","Discovery of the Americas","Storming of the Bastille","Battle of Plataea","Founding of Rome","First Crusade"],"instant_feedback":true,"feedback_attempts":2,"validation":{"valid_response":[4,3,5,1,2,0],"valid_score":1,"partial_scoring":true,"penalty_score":-1}},{"response_id":"demoscience5678","type":"highlight","description":"The student needs to mark one of the flowers anthers in the image.","img_src":"http://www.learnosity.com/static/img/flower.jpg","line_color":"rgb(255, 20, 0)","line_width":"4"}],"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8"},"type":"activity"}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $assessApiV1;
-
-        $assessApiV2 = [
-            '{"items":[{"content":"<span class=\"learnosity-response question-demoscience1234\"></span>","response_ids":["demoscience1234"],"workflow":"","reference":"question-demoscience1"},{"content":"<span class=\"learnosity-response question-demoscience5678\"></span>","response_ids":["demoscience5678"],"workflow":"","reference":"question-demoscience2"}],"ui_style":"horizontal","name":"Demo (2 questions)","state":"initial","metadata":[],"navigation":{"show_next":true,"toc":true,"show_submit":true,"show_save":false,"show_prev":true,"show_title":true,"show_intro":true},"time":{"max_time":600,"limit_type":"soft","show_pause":true,"warning_time":60,"show_time":true},"configuration":{"onsubmit_redirect_url":"/assessment/","onsave_redirect_url":"/assessment/","idle_timeout":true,"questionsApiVersion":"v2"},"questionsApiActivity":{"user_id":"$ANONYMIZED_USER_ID","type":"submit_practice","state":"initial","id":"assessdemo","name":"Assess API - Demo","questions":[{"response_id":"demoscience1234","type":"sortlist","description":"In this question, the student needs to sort the events, chronologically earliest to latest.","list":["Russian Revolution","Discovery of the Americas","Storming of the Bastille","Battle of Plataea","Founding of Rome","First Crusade"],"instant_feedback":true,"feedback_attempts":2,"validation":{"valid_response":[4,3,5,1,2,0],"valid_score":1,"partial_scoring":true,"penalty_score":-1}},{"response_id":"demoscience5678","type":"highlight","description":"The student needs to mark one of the flowers anthers in the image.","img_src":"http://www.learnosity.com/static/img/flower.jpg","line_color":"rgb(255, 20, 0)","line_width":"4"}],"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8"},"type":"activity"}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $assessApiV2;
+        $testCases['api-assess'] = $assessApi;
 
         /* Data */
         list($service, $security, $secret, $request, $action) = static::getWorkingDataApiParams();
         $security['timestamp'] = '20140626-0528';
-        $dataApiGetV1 = [
+        $dataApiGet = [
             [
                 'security' => '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$e19c8a62fba81ef6baf2731e2ab0512feaf573ca5ca5929c2ee9a77303d2e197"}',
                 'request'  => '{"limit":100}',
                 'action'   => 'get'
             ],
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $dataApiGetV1;
+        $testCases['api-data_get'] = $dataApiGet;
 
-        $dataApiGetV2 = [
-            [
-                'security' => '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$e19c8a62fba81ef6baf2731e2ab0512feaf573ca5ca5929c2ee9a77303d2e197"}',
-                'request'  => '{"limit":100}',
-                'action'   => 'get'
-            ],
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $dataApiGetV2;
-
-        $dataApiPostV1 = [
+        $dataApiPost = [
             [
                 'security' => '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16"}',
                 'request'  => '{"limit":100}',
                 'action'   => 'post'
             ],
-            new Init($service, $security, $secret, $request, 'post', $this->signatureFactory)
+            $service, $security, $secret, $request, 'post',
         ];
-        $testCases[] = $dataApiPostV1;
-
-        $dataApiPostV2 = [
-            [
-                'security' => '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16"}',
-                'request'  => '{"limit":100}',
-                'action'   => 'post'
-            ],
-            new Init($service, $security, $secret, $request, 'post', $this->signatureFactory, '02')
-        ];
-        $testCases[] = $dataApiPostV2;
+        $testCases['api-data_post'] = $dataApiPost;
 
         /* Events */
         list($service, $security, $secret, $request, $action) = static::getWorkingEventsApiParams();
-        $eventsApiExpectedV1 = '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349"},"config":{"users":{"$ANONYMIZED_USER_ID_1":"64ccf06154cf4133624372459ebcccb8b2f8bd7458a73df681acef4e742e175c","$ANONYMIZED_USER_ID_2":"7fa4d6ef8926add8b6411123fce916367250a6a99f50ab8ec39c99d768377adb","$ANONYMIZED_USER_ID_3":"3d5b26843da9192319036b67f8c5cc26e1e1763811270ba164665d0027296952","$ANONYMIZED_USER_ID_4":"3b6ac78f60f3e3eb7a85cec8b48bdca0f590f959e0a87a9c4222898678bd50c8"}}}';
-
-        $eventsApiV1 = [
-            $eventsApiExpectedV1,
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+        $eventsApiExpected = '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349"},"config":{"users":{"$ANONYMIZED_USER_ID_1":"64ccf06154cf4133624372459ebcccb8b2f8bd7458a73df681acef4e742e175c","$ANONYMIZED_USER_ID_2":"7fa4d6ef8926add8b6411123fce916367250a6a99f50ab8ec39c99d768377adb","$ANONYMIZED_USER_ID_3":"3d5b26843da9192319036b67f8c5cc26e1e1763811270ba164665d0027296952","$ANONYMIZED_USER_ID_4":"3b6ac78f60f3e3eb7a85cec8b48bdca0f590f959e0a87a9c4222898678bd50c8"}}}';
+        $eventsApi = [
+            $eventsApiExpected,
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $eventsApiV1;
-
-        $eventsApiExpectedV2 = '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349"},"config":{"users":{"$ANONYMIZED_USER_ID_1":"64ccf06154cf4133624372459ebcccb8b2f8bd7458a73df681acef4e742e175c","$ANONYMIZED_USER_ID_2":"7fa4d6ef8926add8b6411123fce916367250a6a99f50ab8ec39c99d768377adb","$ANONYMIZED_USER_ID_3":"3d5b26843da9192319036b67f8c5cc26e1e1763811270ba164665d0027296952","$ANONYMIZED_USER_ID_4":"3b6ac78f60f3e3eb7a85cec8b48bdca0f590f959e0a87a9c4222898678bd50c8"}}}';
-        $eventsApiV2 = [
-            $eventsApiExpectedV2,
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $eventsApiV2;
+        $testCases['api-events'] = $eventsApi;
 
         /* Items */
         list($service, $security, $secret, $request, $action) = static::getWorkingItemsApiParams();
-        $itemsApiV1 = [
+        $itemsApi = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9"},"request":{"user_id":"$ANONYMIZED_USER_ID","rendering_type":"assess","name":"Items API demo - assess activity demo","state":"initial","activity_id":"items_assess_demo","session_id":"demo_session_uuid","type":"submit_practice","config":{"configuration":{"responsive_regions":true},"navigation":{"scrolling_indicator":true},"regions":"main","time":{"show_pause":true,"max_time":300},"title":"ItemsAPI Assess Isolation Demo","subtitle":"Testing Subtitle Text"},"items":["Demo3"]}}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $itemsApiV1;
-
-        $itemsApiV2 = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9"},"request":{"user_id":"$ANONYMIZED_USER_ID","rendering_type":"assess","name":"Items API demo - assess activity demo","state":"initial","activity_id":"items_assess_demo","session_id":"demo_session_uuid","type":"submit_practice","config":{"configuration":{"responsive_regions":true},"navigation":{"scrolling_indicator":true},"regions":"main","time":{"show_pause":true,"max_time":300},"title":"ItemsAPI Assess Isolation Demo","subtitle":"Testing Subtitle Text"},"items":["Demo3"]}}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $itemsApiV2;
+        $testCases['api-items'] = $itemsApi;
 
         /* Questions */
         list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
-        $questionsApiV1 = [
+        $questionsApi = [
             '{"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8","type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}]}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $questionsApiV1;
-
-        $questionsApiV2 = [
-            '{"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8","type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}]}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $questionsApiV2;
+        $testCases['api-questions'] = $questionsApi;
 
         /* Reports */
         list($service, $security, $secret, $request, $action) = static::getWorkingReportsApiParams();
-        $reportsApiV1 = [
+        $reportsApi = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84"},"request":{"reports":[{"id":"report-1","type":"sessions-summary","user_id":"$ANONYMIZED_USER_ID","session_ids":["AC023456-2C73-44DC-82DA28894FCBC3BF"]}]}}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $reportsApiV1;
-
-        $reportsApiV2 = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84"},"request":{"reports":[{"id":"report-1","type":"sessions-summary","user_id":"$ANONYMIZED_USER_ID","session_ids":["AC023456-2C73-44DC-82DA28894FCBC3BF"]}]}}',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $reportsApiV2;
+        $testCases['api-reports'] = $reportsApi;
 
         /* Passing request as string */
         list($service, $security, $secret, $request, $action) = static::getWorkingAuthorApiParams();
-        $authorApiAsStringV1 = [
+        $authorApiAsString = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861"},"request":"{\"mode\":\"item_list\",\"config\":{\"item_list\":{\"item\":{\"status\":true}}},\"user\":{\"id\":\"walterwhite\",\"firstname\":\"walter\",\"lastname\":\"white\"}}"}',
-            new Init($service, $security, $secret, json_encode($request), $action, $this->signatureFactory)
+            $service, $security, $secret, json_encode($request), $action,
         ];
-        $testCases[] = $authorApiAsStringV1;
-
-        $authorApiAsStringV2 = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861"},"request":"{\"mode\":\"item_list\",\"config\":{\"item_list\":{\"item\":{\"status\":true}}},\"user\":{\"id\":\"walterwhite\",\"firstname\":\"walter\",\"lastname\":\"white\"}}"}',
-            new Init($service, $security, $secret, json_encode($request), $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $authorApiAsStringV2;
+        $testCases['api-author_string'] = $authorApiAsString;
 
         list($service, $security, $secret, $request, $action) = static::getWorkingAuthorAideApiParams();
         $authorAideApiAsString = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$f2ce1da2fdead193d53ab954b8a3660548ed9b0e3ce60599d751130deba7a138"},"request":"{\"config\":{\"test-attribute\":\"test\"},\"user\":{\"id\":\"walterwhite\",\"firstname\":\"walter\",\"lastname\":\"white\"}}"}',
-            new Init($service, $security, $secret, json_encode($request), $action, $this->signatureFactory)
+            $service, $security, $secret, json_encode($request), $action,
         ];
-        $testCases[] = $authorAideApiAsString;
+        $testCases['api-authoraide_string'] = $authorAideApiAsString;
 
         /* Items */
         list($service, $security, $secret, $request, $action) = static::getWorkingItemsApiParams();
-        $itemsApiAsStringV1 = [
+        $itemsApiAsString = [
             '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9"},"request":"{\"user_id\":\"$ANONYMIZED_USER_ID\",\"rendering_type\":\"assess\",\"name\":\"Items API demo - assess activity demo\",\"state\":\"initial\",\"activity_id\":\"items_assess_demo\",\"session_id\":\"demo_session_uuid\",\"type\":\"submit_practice\",\"config\":{\"configuration\":{\"responsive_regions\":true},\"navigation\":{\"scrolling_indicator\":true},\"regions\":\"main\",\"time\":{\"show_pause\":true,\"max_time\":300},\"title\":\"ItemsAPI Assess Isolation Demo\",\"subtitle\":\"Testing Subtitle Text\"},\"items\":[\"Demo3\"]}"}',
-            new Init($service, $security, $secret, json_encode($request), $action, $this->signatureFactory)
+            $service, $security, $secret, json_encode($request), $action,
         ];
-        $testCases[] = $itemsApiAsStringV1;
-
-        $itemsApiAsStringV2 = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9"},"request":"{\"user_id\":\"$ANONYMIZED_USER_ID\",\"rendering_type\":\"assess\",\"name\":\"Items API demo - assess activity demo\",\"state\":\"initial\",\"activity_id\":\"items_assess_demo\",\"session_id\":\"demo_session_uuid\",\"type\":\"submit_practice\",\"config\":{\"configuration\":{\"responsive_regions\":true},\"navigation\":{\"scrolling_indicator\":true},\"regions\":\"main\",\"time\":{\"show_pause\":true,\"max_time\":300},\"title\":\"ItemsAPI Assess Isolation Demo\",\"subtitle\":\"Testing Subtitle Text\"},\"items\":[\"Demo3\"]}"}',
-            new Init($service, $security, $secret, json_encode($request), $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $itemsApiAsStringV2;
+        $testCases['api-items_string'] = $itemsApiAsString;
 
         Init::enableTelemetry();
 
         return $testCases;
     }
 
+    /** @return array:
+     *  - string $expectedSignature
+     *  - string $service
+     *  - array $security
+     *  - string $secret
+     *  - array|string $request
+     *  - ?string $action
+     */
     public function generateSignatureProvider(): array
     {
-        // We disable telemetry to be able to reliably test signature generation. Added telemetry
-        // will differ on each platform tests would be run, and therefore fail.
-        Init::disableTelemetry();
-
         $testCases = [];
 
         /* Author */
         list($service, $security, $secret, $request, $action) = static::getWorkingAuthorApiParams();
-        $authorApiV1 = [
+        $authorApi = [
             '$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $authorApiV1;
-
-        $authorApiV2 = [
-            '$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $authorApiV2;
-
-        list($service, $security, $secret, $request, $action) = static::getWorkingAuthorAideApiParams();
-        $authorAide = [
-            '$02$f2ce1da2fdead193d53ab954b8a3660548ed9b0e3ce60599d751130deba7a138',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
-        ];
-        $testCases[] = $authorAide;
+        $testCases['api-author'] = $authorApi;
 
         /* Assess */
         list($service, $security, $secret, $request, $action) = static::getWorkingAssessApiParams();
-        $assessApiV1 = [
+        $assessApi = [
             '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $assessApiV1;
-
-        $assessApiV2 = [
-            '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $assessApiV2;
+        $testCases['api-assess'] = $assessApi;
 
         /* Data */
         list($service, $security, $secret, $request, $action) = static::getWorkingDataApiParams();
         $securityExpires = $security;
         $securityExpires['expires'] = '20160621-1716';
 
-        $dataApiV1 = [
+        $dataApi = [
             '$02$e19c8a62fba81ef6baf2731e2ab0512feaf573ca5ca5929c2ee9a77303d2e197',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $dataApiV1;
+        $testCases['api-data'] = $dataApi;
 
-        $dataApiV2 = [
-            '$02$e19c8a62fba81ef6baf2731e2ab0512feaf573ca5ca5929c2ee9a77303d2e197',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $dataApiV2;
-
-        $dataApiPostV1 = [
+        $dataApiPost = [
             '$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16',
-            new Init($service, $security, $secret, $request, 'post', $this->signatureFactory)
+            $service, $security, $secret, $request, 'post',
         ];
-        $testCases[] = $dataApiPostV1;
+        $testCases['api-data_post'] = $dataApiPost;
 
-        $dataApiPostV2 = [
-            '$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16',
-            new Init($service, $security, $secret, $request, 'post', $this->signatureFactory, '02')
-        ];
-        $testCases[] = $dataApiPostV2;
-
-        $dataApiExpireV1 = [
+        $dataApiExpire = [
             '$02$579bbf967c9fa886865fc85313bf0f70bdf3636a78732439ea19d6c2b908f49c',
-            new Init($service, $securityExpires, $secret, $request, $action, $this->signatureFactory)
+            $service, $securityExpires, $secret, $request, $action,
         ];
-        $testCases[] = $dataApiExpireV1;
-        $dataApiExpireV2 = [
-            '$02$579bbf967c9fa886865fc85313bf0f70bdf3636a78732439ea19d6c2b908f49c',
-            new Init($service, $securityExpires, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $dataApiExpireV2;
+        $testCases['api-data_expire'] = $dataApiExpire;
 
         /* Events */
         list($service, $security, $secret, $request, $action) = static::getWorkingEventsApiParams();
-        $eventsApiV1 = [
+        $eventsApi = [
             '$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $eventsApiV1;
-
-        $eventsApiV2 = [
-            '$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $eventsApiV2;
+        $testCases['api-events'] = $eventsApi;
 
         /* Items */
         list($service, $security, $secret, $request, $action) = static::getWorkingItemsApiParams();
-        $itemsApiV1 = [
+        $itemsApi = [
             '$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $itemsApiV1;
-
-        $itemsApiV2 = [
-            '$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $itemsApiV2;
+        $testCases['api-items'] = $itemsApi;
 
         /* Questions */
         list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
-        $questionsApiV1 = [
+        $questionsApi = [
             '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $questionsApiV1;
-
-        $questionsApiV2 = [
-            '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $questionsApiV2;
+        $testCases['api-questions'] = $questionsApi;
 
         /* Reports */
         list($service, $security, $secret, $request, $action) = static::getWorkingReportsApiParams();
-        $reportsApiV1 = [
+        $reportsApi = [
             '$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory)
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $reportsApiV1;
-
-        $reportsApiV2 = [
-            '$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84',
-            new Init($service, $security, $secret, $request, $action, $this->signatureFactory, '02')
-        ];
-        $testCases[] = $reportsApiV2;
-
-        Init::enableTelemetry();
+        $testCases['api-reports'] = $reportsApi;
 
         return $testCases;
     }
 
+    /** @return array:
+     *  - string $pathToMeta
+     *  - string $service
+     *  - array $security
+     *  - string $secret
+     *  - array|string $request
+     *  - ?string $action
+     */
     public function generateWithMetaProvider(): array
     {
-        Init::enableTelemetry();
-
         $testCases = [];
 
         /* Author */
         list($service, $security, $secret, $request, $action) = static::getWorkingAuthorApiParams();
         $authorApi = [
             'request.meta',
-            (new Init($service, $security, $secret, $request, $action, $this->signatureFactory))->generate()
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $authorApi;
+        $testCases['api-author'] = $authorApi;
 
+        /* Author Aide */
         list($service, $security, $secret, $request, $action) = static::getWorkingAuthorAideApiParams();
         $authorAideApi = [
             'request.meta',
-            (new Init($service, $security, $secret, $request, $action, $this->signatureFactory))->generate()
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $authorAideApi;
+        $testCases['api-authoraide'] = $authorAideApi;
 
         /* Assess */
         list($service, $security, $secret, $request, $action) = static::getWorkingAssessApiParams();
         $assessApi = [
             'meta',
-            (new Init($service, $security, $secret, $request, $action, $this->signatureFactory))->generate()
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $assessApi;
+        $testCases['api-assess'] = $assessApi;
 
         /* Data */
         list($service, $security, $secret, $request, $action) = static::getWorkingDataApiParams();
         $dataApi = [
             'request.meta',
-            (new Init($service, $security, $secret, $request, $action, $this->signatureFactory))->generate()
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $dataApi;
+        $testCases['api-data'] = $dataApi;
 
         /* Events */
         list($service, $security, $secret, $request, $action) = static::getWorkingEventsApiParams();
         $eventsApi = [
             'config.meta',
-            (new Init($service, $security, $secret, $request, $action, $this->signatureFactory))->generate()
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $eventsApi;
+        $testCases['api-events'] = $eventsApi;
 
         /* Items */
         list($service, $security, $secret, $request, $action) = static::getWorkingItemsApiParams();
         $itemsApi = [
             'request.meta',
-            (new Init($service, $security, $secret, $request, $action, $this->signatureFactory))->generate()
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $itemsApi;
+        $testCases['api-items'] = $itemsApi;
 
         /* Questions */
         list($service, $security, $secret, $request, $action) = static::getWorkingQuestionsApiParams();
         $questionsApi = [
             'meta',
-            (new Init($service, $security, $secret, $request, $action, $this->signatureFactory))->generate()
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $questionsApi;
+        $testCases['api-questions'] = $questionsApi;
 
         /* Reports */
         list($service, $security, $secret, $request, $action) = static::getWorkingReportsApiParams();
         $reportsApi = [
             'request.meta',
-            (new Init($service, $security, $secret, $request, $action, $this->signatureFactory))->generate()
+            $service, $security, $secret, $request, $action,
         ];
-        $testCases[] = $reportsApi;
+        $testCases['api-reports'] = $reportsApi;
 
         Init::disableTelemetry();
 

--- a/tests/Request/InitTest.php
+++ b/tests/Request/InitTest.php
@@ -35,6 +35,10 @@ class InitTest extends AbstractTestCase
             $this->expectException($expectedException);
             $this->expectExceptionMessage($expectedExceptionMessage);
         }
+        // We disable telemetry to be able to reliably test signature generation. Added telemetry
+        // will differ on each platform tests would be run, and therefore fail.
+        Init::disableTelemetry();
+
 
         $init = new Init($service, $securityPacket, $secret, $requestPacket, $action);
 
@@ -191,6 +195,8 @@ class InitTest extends AbstractTestCase
 
     public function testRequestWithoutTelemetryPreservesEmptyMeta()
     {
+        // We disable telemetry to be able to reliably test signature generation. Added telemetry
+        // will differ on each platform tests would be run, and therefore fail.
         Init::disableTelemetry();
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
 
@@ -204,6 +210,8 @@ class InitTest extends AbstractTestCase
 
     public function testRequestWithoutTelemetryPreservesFilledMeta()
     {
+        // We disable telemetry to be able to reliably test signature generation. Added telemetry
+        // will differ on each platform tests would be run, and therefore fail.
         Init::disableTelemetry();
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
 
@@ -233,22 +241,123 @@ class InitTest extends AbstractTestCase
 
     public function constructorProvider(): array
     {
+        // We disable telemetry to be able to reliably test signature generation. Added telemetry
+        // will differ on each platform tests would be run, and therefore fail.
+        Init::disableTelemetry();
+
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
 
         $wrongSecurity = $security;
         $wrongSecurity['wrongParam'] = '';
 
         return [
-            [$service, $security, $secret, $request, $action, new Init($service, $security, $secret, $request, $action)],
-            ['', $security, $secret, $request, $action, null, ValidationException::class, 'The `service` argument wasn\'t found or was empty'],
-            ['wrongService', $security, $secret, $request, $action, null, ValidationException::class, 'The service provided (wrongService) is not valid'],
-            [$service, '', $secret, $request, $action, null, ValidationException::class, 'The security packet must be an array or a valid JSON string'],
-            [$service, null, $secret, $request, $action, null, ValidationException::class, 'The security packet must be an array or a valid JSON string'],
-            [$service, '', $secret, $request, $action, null, ValidationException::class, 'The security packet must be an array or a valid JSON string'],
-            [$service, $security, '', $request, $action, null, ValidationException::class, 'The `secret` argument must be a valid string'],
-            [$service, $wrongSecurity, $secret, $request, $action, null, ValidationException::class, 'Invalid key found in the security packet: wrongParam'],
-            ['questions', $security, $secret, $request, $action, null, ValidationException::class, 'Questions API requires a `user_id` in the security packet'],
-            [$service, $security, $secret, 25, $action, null, ValidationException::class, 'The request packet must be an array or a valid JSON string'],
+            'valid-api-data' => [
+                $service,
+                $security,
+                $secret,
+                $request,
+                $action,
+                new Init($service, $security, $secret, $request, $action)
+            ],
+            'empty-service' => [
+                '',
+                $security,
+                $secret,
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'The `service` argument wasn\'t found or was empty'
+            ],
+            'invalid-service' => [
+                'wrongService',
+                $security,
+                $secret,
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'The service provided (wrongService) is not valid'
+            ],
+            'empty-security' => [
+
+                $service,
+                '',
+                $secret,
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'The security packet must be an array or a valid JSON string'
+            ],
+            'empty-security' => [
+
+                $service,
+                '',
+                $secret,
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'The security packet must be an array or a valid JSON string'
+            ],
+            'null-security' => [
+
+                $service,
+                null,
+                $secret,
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'The security packet must be an array or a valid JSON string'
+            ],
+            'empty-secret' => [
+
+                $service,
+                $security,
+                '',
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'The `secret` argument must be a valid string'
+            ],
+            'incorrect-security' => [
+
+                $service,
+                $wrongSecurity,
+                $secret,
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'Invalid key found in the security packet: wrongParam'
+            ],
+            'missing-questions_user_id' =>
+            [
+
+                'questions',
+                $security,
+                $secret,
+                $request,
+                $action,
+                null,
+                ValidationException::class,
+                'Questions API requires a `user_id` in the security packet'
+            ],
+            'invalid-request' =>
+            [
+
+                $service,
+                $security,
+                $secret,
+                25,
+                $action,
+                null,
+                ValidationException::class,
+                'The request packet must be an array or a valid JSON string'
+            ],
         ];
     }
 
@@ -283,14 +392,13 @@ class InitTest extends AbstractTestCase
         /* Assess */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAssessApiParams();
         $assessApi = [
-            '{"items":[{"content":"<span class=\"learnosity-response question-demoscience1234\"></span>","response_ids":["demoscience1234"],"workflow":"","reference":"question-demoscience1"},{"content":"<span class=\"learnosity-response question-demoscience5678\"></span>","response_ids":["demoscience5678"],"workflow":"","reference":"question-demoscience2"}],"ui_style":"horizontal","name":"Demo (2 questions)","state":"initial","metadata":[],"navigation":{"show_next":true,"toc":true,"show_submit":true,"show_save":false,"show_prev":true,"show_title":true,"show_intro":true},"time":{"max_time":600,"limit_type":"soft","show_pause":true,"warning_time":60,"show_time":true},"configuration":{"onsubmit_redirect_url":"/assessment/","onsave_redirect_url":"/assessment/","idle_timeout":true,"questionsApiVersion":"v2"},"questionsApiActivity":{"user_id":"$ANONYMIZED_USER_ID","type":"submit_practice","state":"initial","id":"assessdemo","name":"Assess API - Demo","questions":[{"response_id":"demoscience1234","type":"sortlist","description":"In this question, the student needs to sort the events, chronologically earliest to latest.","list":["Russian Revolution","Discovery of the Americas","Storming of the Bastille","Battle of Plataea","Founding of Rome","First Crusade"],"instant_feedback":true,"feedback_attempts":2,"validation":{"valid_response":[4,3,5,1,2,0],"valid_score":1,"partial_scoring":true,"penalty_score":-1}},{"response_id":"demoscience5678","type":"highlight","description":"The student needs to mark one of the flowers anthers in the image.","img_src":"http://www.learnosity.com/static/img/flower.jpg","line_color":"rgb(255, 20, 0)","line_width":"4"}],"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8"},"type":"activity"}',
+            '{"items":[{"content":"<span class=\"learnosity-response question-demoscience1234\"></span>","response_ids":["demoscience1234"],"workflow":"","reference":"question-demoscience1"},{"content":"<span class=\"learnosity-response question-demoscience5678\"></span>","response_ids":["demoscience5678"],"workflow":"","reference":"question-demoscience2"}],"ui_style":"horizontal","name":"Demo (2 questions)","state":"initial","metadata":[],"navigation":{"show_next":true,"toc":true,"show_submit":true,"show_save":false,"show_prev":true,"show_title":true,"show_intro":true},"time":{"max_time":600,"limit_type":"soft","show_pause":true,"warning_time":60,"show_time":true},"configuration":{"onsubmit_redirect_url":"/assessment/","onsave_redirect_url":"/assessment/","idle_timeout":true,"questionsApiVersion":"v2"},"questionsApiActivity":{"type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}],"user_id":"$ANONYMIZED_USER_ID","name":"Assess API - Demo","id":"assessdemo","consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8"},"type":"activity"}',
             $service, $security, $secret, $request, $action,
         ];
         $testCases['api-assess'] = $assessApi;
 
         /* Data */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
-        $security['timestamp'] = '20140626-0528';
         $dataApiGet = [
             [
                 'security' => '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$e19c8a62fba81ef6baf2731e2ab0512feaf573ca5ca5929c2ee9a77303d2e197"}',
@@ -309,6 +417,7 @@ class InitTest extends AbstractTestCase
             ],
             $service, $security, $secret, $request, 'post',
         ];
+        // XXX: post is not a valid action; should be set
         $testCases['api-data_post'] = $dataApiPost;
 
         /* Events */
@@ -415,6 +524,7 @@ class InitTest extends AbstractTestCase
             '$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16',
             $service, $security, $secret, $request, 'post',
         ];
+        // XXX: post is not a valid action; should be set
         $testCases['api-data_post'] = $dataApiPost;
 
         $dataApiExpire = [
@@ -533,8 +643,6 @@ class InitTest extends AbstractTestCase
             $service, $security, $secret, $request, $action,
         ];
         $testCases['api-reports'] = $reportsApi;
-
-        Init::disableTelemetry();
 
         return $testCases;
     }

--- a/tests/Request/InitTest.php
+++ b/tests/Request/InitTest.php
@@ -6,9 +6,11 @@ use LearnositySdk\AbstractTestCase; // XXX: should be in a Test namespace
 use LearnositySdk\Exceptions\ValidationException;
 use LearnositySdk\Fixtures\ParamsFixture; // XXX: should be in a Test namespace
 use LearnositySdk\Services\SignatureFactory;
+use LearnositySdk\Services\Signatures\HmacSignature;
 
 class InitTest extends AbstractTestCase
 {
+    const SDK_SIGNATURE_VERSION = HmacSignature::SIGNATURE_VERSION;
     /**
      * @var \LearnositySdk\Services\SignatureFactory
      */
@@ -251,113 +253,113 @@ class InitTest extends AbstractTestCase
         $wrongSecurity['wrongParam'] = '';
 
         return [
-            'valid-api-data' => [
-                $service,
-                $security,
-                $secret,
-                $request,
-                $action,
-                new Init($service, $security, $secret, $request, $action)
-            ],
-            'empty-service' => [
-                '',
-                $security,
-                $secret,
-                $request,
-                $action,
-                null,
-                ValidationException::class,
-                'The `service` argument wasn\'t found or was empty'
-            ],
-            'invalid-service' => [
-                'wrongService',
-                $security,
-                $secret,
-                $request,
-                $action,
-                null,
-                ValidationException::class,
-                'The service provided (wrongService) is not valid'
-            ],
-            'empty-security' => [
+        'valid-api-data' => [
+            $service,
+            $security,
+            $secret,
+            $request,
+            $action,
+            new Init($service, $security, $secret, $request, $action)
+        ],
+        'empty-service' => [
+            '',
+            $security,
+            $secret,
+            $request,
+            $action,
+            null,
+            ValidationException::class,
+            'The `service` argument wasn\'t found or was empty'
+        ],
+        'invalid-service' => [
+            'wrongService',
+            $security,
+            $secret,
+            $request,
+            $action,
+            null,
+            ValidationException::class,
+            'The service provided (wrongService) is not valid'
+        ],
+        'empty-security' => [
 
-                $service,
-                '',
-                $secret,
-                $request,
-                $action,
-                null,
-                ValidationException::class,
-                'The security packet must be an array or a valid JSON string'
-            ],
-            'empty-security' => [
+            $service,
+            '',
+            $secret,
+            $request,
+            $action,
+            null,
+            ValidationException::class,
+            'The security packet must be an array or a valid JSON string'
+        ],
+        'empty-security' => [
 
-                $service,
-                '',
-                $secret,
-                $request,
-                $action,
-                null,
-                ValidationException::class,
-                'The security packet must be an array or a valid JSON string'
-            ],
-            'null-security' => [
+            $service,
+            '',
+            $secret,
+            $request,
+            $action,
+            null,
+            ValidationException::class,
+            'The security packet must be an array or a valid JSON string'
+        ],
+        'null-security' => [
 
-                $service,
-                null,
-                $secret,
-                $request,
-                $action,
-                null,
-                ValidationException::class,
-                'The security packet must be an array or a valid JSON string'
-            ],
-            'empty-secret' => [
+            $service,
+            null,
+            $secret,
+            $request,
+            $action,
+            null,
+            ValidationException::class,
+            'The security packet must be an array or a valid JSON string'
+        ],
+        'empty-secret' => [
 
-                $service,
-                $security,
-                '',
-                $request,
-                $action,
-                null,
-                ValidationException::class,
-                'The `secret` argument must be a valid string'
-            ],
-            'incorrect-security' => [
+            $service,
+            $security,
+            '',
+            $request,
+            $action,
+            null,
+            ValidationException::class,
+            'The `secret` argument must be a valid string'
+        ],
+        'incorrect-security' => [
 
-                $service,
-                $wrongSecurity,
-                $secret,
-                $request,
-                $action,
-                null,
-                ValidationException::class,
-                'Invalid key found in the security packet: wrongParam'
-            ],
-            'missing-questions_user_id' =>
-            [
+            $service,
+            $wrongSecurity,
+            $secret,
+            $request,
+            $action,
+            null,
+            ValidationException::class,
+            'Invalid key found in the security packet: wrongParam'
+        ],
+        'missing-questions_user_id' =>
+        [
 
-                'questions',
-                $security,
-                $secret,
-                $request,
-                $action,
-                null,
-                ValidationException::class,
-                'Questions API requires a `user_id` in the security packet'
-            ],
-            'invalid-request' =>
-            [
+            'questions',
+            $security,
+            $secret,
+            $request,
+            $action,
+            null,
+            ValidationException::class,
+            'Questions API requires a `user_id` in the security packet'
+        ],
+        'invalid-request' =>
+        [
 
-                $service,
-                $security,
-                $secret,
-                25,
-                $action,
-                null,
-                ValidationException::class,
-                'The request packet must be an array or a valid JSON string'
-            ],
+            $service,
+            $security,
+            $secret,
+            25,
+            $action,
+            null,
+            ValidationException::class,
+            'The request packet must be an array or a valid JSON string'
+        ],
         ];
     }
 
@@ -375,33 +377,56 @@ class InitTest extends AbstractTestCase
 
         /* Author */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorApiParams();
+        $authorApiSig = ParamsFixture::getAuthorApiSignatureForVersion(static::SDK_SIGNATURE_VERSION);
         $authorApi = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861"},"request":{"mode":"item_list","config":{"item_list":{"item":{"status":true}}},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}}',
+            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"'
+                . $authorApiSig . '"},"request":{"mode":"item_list","config":{"item_list":{"item":{"status":true}}},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}}',
             $service, $security, $secret, $request, $action,
         ];
         $testCases['api-author'] = $authorApi;
 
+        $authorApiAsString = [
+            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"'
+                . $authorApiSig . '"},"request":"{\"mode\":\"item_list\",\"config\":{\"item_list\":{\"item\":{\"status\":true}}},\"user\":{\"id\":\"walterwhite\",\"firstname\":\"walter\",\"lastname\":\"white\"}}"}',
+            $service, $security, $secret, json_encode($request), $action,
+        ];
+        $testCases['api-author_string'] = $authorApiAsString;
+
         /* Author Aide */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorAideApiParams();
+        $authorAideApiSig = ParamsFixture::getAuthorAideApiSignatureForVersion(static::SDK_SIGNATURE_VERSION);
         $authorAideApi = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$f2ce1da2fdead193d53ab954b8a3660548ed9b0e3ce60599d751130deba7a138"},"request":{"config":{"test-attribute":"test"},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}}',
+            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"'
+                . $authorAideApiSig . '"},"request":{"config":{"test-attribute":"test"},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}}',
             $service, $security, $secret, $request, $action,
         ];
         $testCases['api-authoraide'] = $authorAideApi;
 
+        $authorAideApiAsString = [
+            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"'
+                . $authorAideApiSig . '"},"request":"{\"config\":{\"test-attribute\":\"test\"},\"user\":{\"id\":\"walterwhite\",\"firstname\":\"walter\",\"lastname\":\"white\"}}"}',
+            $service, $security, $secret, json_encode($request), $action,
+        ];
+        $testCases['api-authoraide_string'] = $authorAideApiAsString;
+
         /* Assess */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAssessApiParams();
+        $assessApiSig = ParamsFixture::getAssessApiSignatureForVersion(static::SDK_SIGNATURE_VERSION);
         $assessApi = [
-            '{"items":[{"content":"<span class=\"learnosity-response question-demoscience1234\"></span>","response_ids":["demoscience1234"],"workflow":"","reference":"question-demoscience1"},{"content":"<span class=\"learnosity-response question-demoscience5678\"></span>","response_ids":["demoscience5678"],"workflow":"","reference":"question-demoscience2"}],"ui_style":"horizontal","name":"Demo (2 questions)","state":"initial","metadata":[],"navigation":{"show_next":true,"toc":true,"show_submit":true,"show_save":false,"show_prev":true,"show_title":true,"show_intro":true},"time":{"max_time":600,"limit_type":"soft","show_pause":true,"warning_time":60,"show_time":true},"configuration":{"onsubmit_redirect_url":"/assessment/","onsave_redirect_url":"/assessment/","idle_timeout":true,"questionsApiVersion":"v2"},"questionsApiActivity":{"type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}],"user_id":"$ANONYMIZED_USER_ID","name":"Assess API - Demo","id":"assessdemo","consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8"},"type":"activity"}',
+            '{"items":[{"content":"<span class=\"learnosity-response question-demoscience1234\"></span>","response_ids":["demoscience1234"],"workflow":"","reference":"question-demoscience1"},{"content":"<span class=\"learnosity-response question-demoscience5678\"></span>","response_ids":["demoscience5678"],"workflow":"","reference":"question-demoscience2"}],"ui_style":"horizontal","name":"Demo (2 questions)","state":"initial","metadata":[],"navigation":{"show_next":true,"toc":true,"show_submit":true,"show_save":false,"show_prev":true,"show_title":true,"show_intro":true},"time":{"max_time":600,"limit_type":"soft","show_pause":true,"warning_time":60,"show_time":true},"configuration":{"onsubmit_redirect_url":"/assessment/","onsave_redirect_url":"/assessment/","idle_timeout":true,"questionsApiVersion":"v2"},"questionsApiActivity":{"type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}],"user_id":"$ANONYMIZED_USER_ID","name":"Assess API - Demo","id":"assessdemo","consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","signature":"'
+                . $assessApiSig . '"},"type":"activity"}',
             $service, $security, $secret, $request, $action,
         ];
         $testCases['api-assess'] = $assessApi;
 
         /* Data */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
+        $dataApiSig = ParamsFixture::getDataApiSignatureForVersion(static::SDK_SIGNATURE_VERSION);
         $dataApiGet = [
             [
-                'security' => '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$e19c8a62fba81ef6baf2731e2ab0512feaf573ca5ca5929c2ee9a77303d2e197"}',
+                'security' =>
+                    '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"'
+                    . $dataApiSig . '"}',
                 'request'  => '{"limit":100}',
                 'action'   => 'get'
             ],
@@ -411,7 +436,9 @@ class InitTest extends AbstractTestCase
 
         $dataApiPost = [
             [
-                'security' => '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16"}',
+                'security' =>
+                    '{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"'
+                    . '$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16"}',
                 'request'  => '{"limit":100}',
                 'action'   => 'post'
             ],
@@ -422,7 +449,9 @@ class InitTest extends AbstractTestCase
 
         /* Events */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingEventsApiParams();
-        $eventsApiExpected = '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349"},"config":{"users":{"$ANONYMIZED_USER_ID_1":"64ccf06154cf4133624372459ebcccb8b2f8bd7458a73df681acef4e742e175c","$ANONYMIZED_USER_ID_2":"7fa4d6ef8926add8b6411123fce916367250a6a99f50ab8ec39c99d768377adb","$ANONYMIZED_USER_ID_3":"3d5b26843da9192319036b67f8c5cc26e1e1763811270ba164665d0027296952","$ANONYMIZED_USER_ID_4":"3b6ac78f60f3e3eb7a85cec8b48bdca0f590f959e0a87a9c4222898678bd50c8"}}}';
+        $eventsApiSig = ParamsFixture::getEventsApiSignatureForVersion(static::SDK_SIGNATURE_VERSION);
+        $eventsApiExpected = '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"'
+            . $eventsApiSig . '"},"config":{"users":{"$ANONYMIZED_USER_ID_1":"64ccf06154cf4133624372459ebcccb8b2f8bd7458a73df681acef4e742e175c","$ANONYMIZED_USER_ID_2":"7fa4d6ef8926add8b6411123fce916367250a6a99f50ab8ec39c99d768377adb","$ANONYMIZED_USER_ID_3":"3d5b26843da9192319036b67f8c5cc26e1e1763811270ba164665d0027296952","$ANONYMIZED_USER_ID_4":"3b6ac78f60f3e3eb7a85cec8b48bdca0f590f959e0a87a9c4222898678bd50c8"}}}';
         $eventsApi = [
             $eventsApiExpected,
             $service, $security, $secret, $request, $action,
@@ -431,64 +460,54 @@ class InitTest extends AbstractTestCase
 
         /* Items */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingItemsApiParams();
+        $itemsApiSig = ParamsFixture::getItemsApiSignatureForVersion(static::SDK_SIGNATURE_VERSION);
         $itemsApi = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9"},"request":{"user_id":"$ANONYMIZED_USER_ID","rendering_type":"assess","name":"Items API demo - assess activity demo","state":"initial","activity_id":"items_assess_demo","session_id":"demo_session_uuid","type":"submit_practice","config":{"configuration":{"responsive_regions":true},"navigation":{"scrolling_indicator":true},"regions":"main","time":{"show_pause":true,"max_time":300},"title":"ItemsAPI Assess Isolation Demo","subtitle":"Testing Subtitle Text"},"items":["Demo3"]}}',
+            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"'
+                . $itemsApiSig . '"},"request":{"user_id":"$ANONYMIZED_USER_ID","rendering_type":"assess","name":"Items API demo - assess activity demo","state":"initial","activity_id":"items_assess_demo","session_id":"demo_session_uuid","type":"submit_practice","config":{"configuration":{"responsive_regions":true},"navigation":{"scrolling_indicator":true},"regions":"main","time":{"show_pause":true,"max_time":300},"title":"ItemsAPI Assess Isolation Demo","subtitle":"Testing Subtitle Text"},"items":["Demo3"]}}',
             $service, $security, $secret, $request, $action,
         ];
         $testCases['api-items'] = $itemsApi;
 
+        $itemsApiAsString = [
+            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"'
+                . $itemsApiSig . '"},"request":"{\"user_id\":\"$ANONYMIZED_USER_ID\",\"rendering_type\":\"assess\",\"name\":\"Items API demo - assess activity demo\",\"state\":\"initial\",\"activity_id\":\"items_assess_demo\",\"session_id\":\"demo_session_uuid\",\"type\":\"submit_practice\",\"config\":{\"configuration\":{\"responsive_regions\":true},\"navigation\":{\"scrolling_indicator\":true},\"regions\":\"main\",\"time\":{\"show_pause\":true,\"max_time\":300},\"title\":\"ItemsAPI Assess Isolation Demo\",\"subtitle\":\"Testing Subtitle Text\"},\"items\":[\"Demo3\"]}"}',
+            $service, $security, $secret, json_encode($request), $action,
+        ];
+        $testCases['api-items_string'] = $itemsApiAsString;
+
         /* Questions */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
+        $questionsApiSig = ParamsFixture::getAssessApiSignatureForVersion(static::SDK_SIGNATURE_VERSION);
         $questionsApi = [
-            '{"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8","type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}]}',
+            '{"consumer_key":"yis0TYCu7U9V4o7M","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"'
+                . $questionsApiSig . '","type":"local_practice","state":"initial","questions":[{"response_id":"60005","type":"association","stimulus":"Match the cities to the parent nation.","stimulus_list":["London","Dublin","Paris","Sydney"],"possible_responses":["Australia","France","Ireland","England"],"validation":{"valid_responses":[["England"],["Ireland"],["France"],["Australia"]]}}]}',
             $service, $security, $secret, $request, $action,
         ];
         $testCases['api-questions'] = $questionsApi;
 
         /* Reports */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingReportsApiParams();
+        $reportsApiSig = ParamsFixture::getReportsApiSignatureForVersion(static::SDK_SIGNATURE_VERSION);
         $reportsApi = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84"},"request":{"reports":[{"id":"report-1","type":"sessions-summary","user_id":"$ANONYMIZED_USER_ID","session_ids":["AC023456-2C73-44DC-82DA28894FCBC3BF"]}]}}',
+            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"'
+                . $reportsApiSig . '"},"request":{"reports":[{"id":"report-1","type":"sessions-summary","user_id":"$ANONYMIZED_USER_ID","session_ids":["AC023456-2C73-44DC-82DA28894FCBC3BF"]}]}}',
             $service, $security, $secret, $request, $action,
         ];
         $testCases['api-reports'] = $reportsApi;
-
-        /* Passing request as string */
-        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorApiParams();
-        $authorApiAsString = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861"},"request":"{\"mode\":\"item_list\",\"config\":{\"item_list\":{\"item\":{\"status\":true}}},\"user\":{\"id\":\"walterwhite\",\"firstname\":\"walter\",\"lastname\":\"white\"}}"}',
-            $service, $security, $secret, json_encode($request), $action,
-        ];
-        $testCases['api-author_string'] = $authorApiAsString;
-
-        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorAideApiParams();
-        $authorAideApiAsString = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$f2ce1da2fdead193d53ab954b8a3660548ed9b0e3ce60599d751130deba7a138"},"request":"{\"config\":{\"test-attribute\":\"test\"},\"user\":{\"id\":\"walterwhite\",\"firstname\":\"walter\",\"lastname\":\"white\"}}"}',
-            $service, $security, $secret, json_encode($request), $action,
-        ];
-        $testCases['api-authoraide_string'] = $authorAideApiAsString;
-
-        /* Items */
-        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingItemsApiParams();
-        $itemsApiAsString = [
-            '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"$ANONYMIZED_USER_ID","signature":"$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9"},"request":"{\"user_id\":\"$ANONYMIZED_USER_ID\",\"rendering_type\":\"assess\",\"name\":\"Items API demo - assess activity demo\",\"state\":\"initial\",\"activity_id\":\"items_assess_demo\",\"session_id\":\"demo_session_uuid\",\"type\":\"submit_practice\",\"config\":{\"configuration\":{\"responsive_regions\":true},\"navigation\":{\"scrolling_indicator\":true},\"regions\":\"main\",\"time\":{\"show_pause\":true,\"max_time\":300},\"title\":\"ItemsAPI Assess Isolation Demo\",\"subtitle\":\"Testing Subtitle Text\"},\"items\":[\"Demo3\"]}"}',
-            $service, $security, $secret, json_encode($request), $action,
-        ];
-        $testCases['api-items_string'] = $itemsApiAsString;
 
         Init::enableTelemetry();
 
         return $testCases;
     }
 
-    /** @return array:
-     *  - string $expectedSignature
-     *  - string $service
-     *  - array $security
-     *  - string $secret
-     *  - array|string $request
-     *  - ?string $action
-     */
+        /** @return array:
+        *  - string $expectedSignature
+        *  - string $service
+        *  - array $security
+        *  - string $secret
+        *  - array|string $request
+        *  - ?string $action
+        */
     public function generateSignatureProvider(): array
     {
         $testCases = [];
@@ -496,86 +515,87 @@ class InitTest extends AbstractTestCase
         /* Author */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorApiParams();
         $authorApi = [
-            '$02$ca2769c4be77037cf22e0f7a2291fe48c470ac6db2f45520a259907370eff861',
-            $service, $security, $secret, $request, $action,
+        ParamsFixture::getAuthorApiSignatureForVersion(static::SDK_SIGNATURE_VERSION),
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-author'] = $authorApi;
 
         /* Assess */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAssessApiParams();
         $assessApi = [
-            '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8',
-            $service, $security, $secret, $request, $action,
+        ParamsFixture::getAssessApiSignatureForVersion(static::SDK_SIGNATURE_VERSION),
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-assess'] = $assessApi;
 
         /* Data */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
-        $securityExpires = $security;
-        $securityExpires['expires'] = '20160621-1716';
 
         $dataApi = [
-            '$02$e19c8a62fba81ef6baf2731e2ab0512feaf573ca5ca5929c2ee9a77303d2e197',
-            $service, $security, $secret, $request, $action,
+        ParamsFixture::getDataApiSignatureForVersion(static::SDK_SIGNATURE_VERSION),
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-data'] = $dataApi;
 
+        /* Events */
         $dataApiPost = [
-            '$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16',
-            $service, $security, $secret, $request, 'post',
+        '$02$9d1971fb9ac51482f7e73dcf87fc029d4a3dfffa05314f71af9d89fb3c2bcf16',
+        $service, $security, $secret, $request, 'post',
         ];
         // XXX: post is not a valid action; should be set
         $testCases['api-data_post'] = $dataApiPost;
 
+        $securityExpires = $security;
+        $securityExpires['expires'] = '20160621-1716';
         $dataApiExpire = [
-            '$02$579bbf967c9fa886865fc85313bf0f70bdf3636a78732439ea19d6c2b908f49c',
-            $service, $securityExpires, $secret, $request, $action,
+        '$02$579bbf967c9fa886865fc85313bf0f70bdf3636a78732439ea19d6c2b908f49c',
+        $service, $securityExpires, $secret, $request, $action,
         ];
         $testCases['api-data_expire'] = $dataApiExpire;
 
         /* Events */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingEventsApiParams();
         $eventsApi = [
-            '$02$5c3160dbb9ab4d01774b5c2fc3b01a35ce4f9709c84571c27dfe333d1ca9d349',
-            $service, $security, $secret, $request, $action,
+        ParamsFixture::getEventsApiSignatureForVersion(static::SDK_SIGNATURE_VERSION),
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-events'] = $eventsApi;
 
         /* Items */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingItemsApiParams();
         $itemsApi = [
-            '$02$36c439e7d18f2347ce08ca4b8d4803a22325d54352650b19b6f4aaa521b613d9',
-            $service, $security, $secret, $request, $action,
+        ParamsFixture::getItemsApiSignatureForVersion(static::SDK_SIGNATURE_VERSION),
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-items'] = $itemsApi;
 
         /* Questions */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
         $questionsApi = [
-            '$02$8de51b7601f606a7f32665541026580d09616028dde9a929ce81cf2e88f56eb8',
-            $service, $security, $secret, $request, $action,
+        ParamsFixture::getQuestionsApiSignatureForVersion(static::SDK_SIGNATURE_VERSION),
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-questions'] = $questionsApi;
 
         /* Reports */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingReportsApiParams();
         $reportsApi = [
-            '$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84',
-            $service, $security, $secret, $request, $action,
+        ParamsFixture::getReportsApiSignatureForVersion(static::SDK_SIGNATURE_VERSION),
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-reports'] = $reportsApi;
 
         return $testCases;
     }
 
-    /** @return array:
-     *  - string $pathToMeta
-     *  - string $service
-     *  - array $security
-     *  - string $secret
-     *  - array|string $request
-     *  - ?string $action
-     */
+        /** @return array:
+        *  - string $pathToMeta
+        *  - string $service
+        *  - array $security
+        *  - string $secret
+        *  - array|string $request
+        *  - ?string $action
+        */
     public function generateWithMetaProvider(): array
     {
         $testCases = [];
@@ -583,64 +603,64 @@ class InitTest extends AbstractTestCase
         /* Author */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorApiParams();
         $authorApi = [
-            'request.meta',
-            $service, $security, $secret, $request, $action,
+        'request.meta',
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-author'] = $authorApi;
 
         /* Author Aide */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAuthorAideApiParams();
         $authorAideApi = [
-            'request.meta',
-            $service, $security, $secret, $request, $action,
+        'request.meta',
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-authoraide'] = $authorAideApi;
 
         /* Assess */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingAssessApiParams();
         $assessApi = [
-            'meta',
-            $service, $security, $secret, $request, $action,
+        'meta',
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-assess'] = $assessApi;
 
         /* Data */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
         $dataApi = [
-            'request.meta',
-            $service, $security, $secret, $request, $action,
+        'request.meta',
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-data'] = $dataApi;
 
         /* Events */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingEventsApiParams();
         $eventsApi = [
-            'config.meta',
-            $service, $security, $secret, $request, $action,
+        'config.meta',
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-events'] = $eventsApi;
 
         /* Items */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingItemsApiParams();
         $itemsApi = [
-            'request.meta',
-            $service, $security, $secret, $request, $action,
+        'request.meta',
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-items'] = $itemsApi;
 
         /* Questions */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingQuestionsApiParams();
         $questionsApi = [
-            'meta',
-            $service, $security, $secret, $request, $action,
+        'meta',
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-questions'] = $questionsApi;
 
         /* Reports */
         list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingReportsApiParams();
         $reportsApi = [
-            'request.meta',
-            $service, $security, $secret, $request, $action,
+        'request.meta',
+        $service, $security, $secret, $request, $action,
         ];
         $testCases['api-reports'] = $reportsApi;
 

--- a/tests/Request/RemoteTest.php
+++ b/tests/Request/RemoteTest.php
@@ -3,12 +3,13 @@
 namespace LearnositySdk\Request;
 
 use LearnositySdk\AbstractTestCase;
+use LearnositySdk\Fixtures\ParamsFixture;
 
 class RemoteTest extends AbstractTestCase
 {
     public function testPost()
     {
-        list($service, $security, $secret, $request, $action) = InitTest::getWorkingDataApiParams();
+        list($service, $security, $secret, $request, $action) = ParamsFixture::getWorkingDataApiParams();
         unset($security['timestamp']);
         $init = new Init($service, $security, $secret, $request, $action);
 

--- a/tests/SdkFactoryTest.php
+++ b/tests/SdkFactoryTest.php
@@ -7,7 +7,7 @@ use LearnositySdk\Request\Init;
 
 class SdkFactoryTest extends AbstractTestCase
 {
-    private  $sdkFactory;
+    private $sdkFactory;
 
     public function setUp(): void
     {
@@ -54,6 +54,7 @@ class SdkFactoryTest extends AbstractTestCase
                     'arguments' => [
                         'service' => 'authoraide',
                         'securityPacket' => [
+                            'consumer_key' => 'test',
                             'domain' => 'test'
                         ]
                     ]
@@ -64,6 +65,7 @@ class SdkFactoryTest extends AbstractTestCase
                     'arguments' => [
                         'service' => 'authoraide',
                         'securityPacket' => [
+                            'consumer_key' => 'test',
                             'domain' => 'test'
                         ],
                         'secret' => 'test'

--- a/tests/Services/LegacySignaturesTest.php
+++ b/tests/Services/LegacySignaturesTest.php
@@ -66,16 +66,19 @@ class LegacySignaturesTest extends AbstractTestCase
 
         foreach ([HashSignature::SIGNATURE_VERSION, HmacSignature::SIGNATURE_VERSION] as $signatureVersion) {
             foreach (LegacyPreHashString::getSupportedServices() as $service) {
-                $getParams = 'getWorking' . ucfirst($service) . 'ApiParams';
-                $getSig = 'get' . ucfirst($service) . 'ApiSignatureForVersion';
+                $expectedSig = ParamsFixture::getSignatureForService($service, $signatureVersion);
+
+                if (empty($expectedSig)) {
+                    /* The deprecation of this signature version predates the addition of this service */
+                    continue;
+                }
 
                 $case = array_merge(
                     [
-                        'expected' =>
-                            ParamsFixture::$getSig($signatureVersion),
+                        'expected' => $expectedSig,
                         'signatureVersion' => $signatureVersion,
                     ],
-                    ParamsFixture::$getParams(true)
+                    ParamsFixture::getWorkingParamsForService($service, true)
                 );
 
                 $testCases["sig-{$signatureVersion}_api-{$service}"] = $case;

--- a/tests/Services/LegacySignaturesTest.php
+++ b/tests/Services/LegacySignaturesTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace LearnositySdk\Services;
+
+use LearnositySdk\AbstractTestCase; // XXX: should be in a Test namespace
+use LearnositySdk\Fixtures\ParamsFixture; // XXX: should be in a Test namespace
+use LearnositySdk\Services\PreHashStrings\LegacyPreHashString;
+use LearnositySdk\Services\SignatureFactory;
+use LearnositySdk\Services\Signatures\HashSignature;
+use LearnositySdk\Services\Signatures\HmacSignature;
+
+class LegacySignaturesTest extends AbstractTestCase
+{
+    private SignatureFactory $signatureFactory;
+
+    public function setUp(): void
+    {
+        $this->signatureFactory = new SignatureFactory();
+    }
+
+    /** @dataProvider legacySignaturesProvider */
+    public function testLegacySignatures(
+        string $expectedSignature,
+        string $signatureVersion,
+        string $service,
+        array $securityPacket,
+        string $secret,
+        array $requestPacket,
+        ?string $action
+    ) {
+        $preHashStringGenerator = new LegacyPreHashString(
+            $service,
+            $signatureVersion == HashSignature::SIGNATURE_VERSION
+        );
+        $secretForPreHashString = $signatureVersion == HashSignature::SIGNATURE_VERSION
+            ? $secret
+            : null;
+        $preHashString = $preHashStringGenerator->getPreHashString(
+            $securityPacket,
+            $requestPacket,
+            $action,
+            $secretForPreHashString
+        );
+        $signatureGenerator = $this->signatureFactory->getSignatureGenerator(
+            $signatureVersion
+        );
+
+        $signature = $signatureGenerator->sign($preHashString, $secret);
+
+        $this->assertEquals($expectedSignature, $signature);
+    }
+
+    /** @return array<
+     *     string $expectedSignature,
+     *     string $signatureVersion,
+     *     string $service,
+     *     array $securityPacket,
+     *     string $secret,
+     *     array $requestPacket,
+     *     ?string $action
+     * >
+     */
+    public function legacySignaturesProvider(): array
+    {
+        $testCases = [];
+
+        foreach ([HashSignature::SIGNATURE_VERSION, HmacSignature::SIGNATURE_VERSION] as $signatureVersion) {
+            foreach (LegacyPreHashString::getSupportedServices() as $service) {
+                $getParams = 'getWorking' . ucfirst($service) . 'ApiParams';
+                $getSig = 'get' . ucfirst($service) . 'ApiSignatureForVersion';
+
+                $case = array_merge(
+                    [
+                        'expected' =>
+                            ParamsFixture::$getSig($signatureVersion),
+                        'signatureVersion' => $signatureVersion,
+                    ],
+                    ParamsFixture::$getParams(true)
+                );
+
+                $testCases["sig-{$signatureVersion}_api-{$service}"] = $case;
+            }
+        }
+
+        return $testCases;
+    }
+}

--- a/tests/Services/PreHashStrings/LegacyPreHashStringTest.php
+++ b/tests/Services/PreHashStrings/LegacyPreHashStringTest.php
@@ -16,7 +16,6 @@ class LegacyPreHashStringTest extends AbstractTestCase
         array|string $request,
         ?string $action,
         bool $v1Compat,
-        bool $requestAsString,
         string $expected
     ) {
         $preHashString = new LegacyPreHashString($service, $v1Compat);
@@ -35,14 +34,11 @@ class LegacyPreHashStringTest extends AbstractTestCase
      *   array|string $request
      *   ?string $action
      *   bool $v1Compat
-     *   bool $requestAsString
      *   string $expected
      * > */
     public function preHashStringProvider()
     {
         $testCases = [];
-
-        $requestAsString = true;
 
         /* Hardcoded prehash strings generated with the last version of the legacy code,
          * based on queries from the ParamsFixture, depending on v1Compat mode */
@@ -72,28 +68,21 @@ class LegacyPreHashStringTest extends AbstractTestCase
 
         foreach ([true, false] as $v1Compat) {
             foreach (LegacyPreHashString::getSupportedServices() as $service) {
-            $camelCaseService = str_replace(
-                ' ',
-                '',
-                ucwords(str_replace('-', ' ', $service))
-            );
-            $getParams = 'getWorking' . $camelCaseService . 'ApiParams';
-                $tc = array_merge(
-                    ParamsFixture::$getParams(true),
+                $case = array_merge(
+                    ParamsFixture::getWorkingParamsForService($service, true),
                     [
-                    'v1Compat' => $v1Compat,
-                    'requestAsString' => $requestAsString,
+                        'v1Compat' => $v1Compat,
                     ]
                 );
 
-                $tc['expected'] = $preHashStrings[$v1Compat][$service];
+                $case['expected'] = $preHashStrings[$v1Compat][$service];
 
                 if (is_null($case['expected'])) {
                     /* New APIs don't need v1Compat support */
                     continue;
                 }
 
-                $testCases["api-{$service}" . ($v1Compat ? '-v1Compat' : '')] = $tc;
+                $testCases["api-{$service}" . ($v1Compat ? '-v1Compat' : '')] = $case;
             }
         }
 

--- a/tests/Services/PreHashStrings/LegacyPreHashStringTest.php
+++ b/tests/Services/PreHashStrings/LegacyPreHashStringTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace LearnositySdk\Services\PreHashStrings;
+
+use LearnositySdk\AbstractTestCase;
+use LearnositySdk\Exceptions\ValidationException;
+use LearnositySdk\Fixtures\ParamsFixture;
+use LearnositySdk\Request\Init;
+
+class LegacyPreHashStringTest extends AbstractTestCase
+{
+    /** @dataProvider preHashStringProvider */
+    public function testPreHashString(
+        string $service,
+        array $security,
+        string $secret,
+        array|string $request,
+        ?string $action,
+        bool $v1Compat,
+        bool $requestAsString,
+        string $expected
+    ) {
+        $preHashString = new LegacyPreHashString($service, $v1Compat);
+        if (is_string($request)) {
+            $request = json_decode($request, true);
+            $this->assertTrue($request !==  false, 'Cannot decode JSON from string request');
+        }
+        $result = $preHashString->getPreHashString($security, $request, $action, $v1Compat ? $secret : null);
+        $this->assertEquals($expected, $result);
+    }
+
+    /** @returns array <
+     *   string $service
+     *   array $security
+     *   string $secret
+     *   array|string $request
+     *   ?string $action
+     *   bool $v1Compat
+     *   bool $requestAsString
+     *   string $expected
+     * > */
+    public function preHashStringProvider()
+    {
+        Init::disableTelemetry();
+        $testCases = [];
+
+        $v1Compat = false;
+        $requestAsString = true;
+
+        foreach (LegacyPreHashString::getSupportedServices() as $service) {
+            $camelCaseService = str_replace(
+                ' ',
+                '',
+                ucwords(str_replace('-', ' ', $service))
+            );
+            $getParams = 'getWorking' . $camelCaseService . 'ApiParams';
+            $tc = array_merge(
+                ParamsFixture::$getParams(true),
+                [
+                    'v1Compat' => $v1Compat,
+                    'requestAsString' => $requestAsString,
+                ]
+            );
+
+            $init = new Init($service, $tc['security'], $tc['secret'], $tc['request'], $tc['action']);
+            $tc['expected'] = $init->generatePreHashString();
+
+            $testCases["api-{$service}"] = $tc;
+        }
+
+        Init::enableTelemetry();
+        return $testCases;
+    }
+}

--- a/tests/Services/PreHashStrings/LegacyPreHashStringTest.php
+++ b/tests/Services/PreHashStrings/LegacyPreHashStringTest.php
@@ -5,7 +5,6 @@ namespace LearnositySdk\Services\PreHashStrings;
 use LearnositySdk\AbstractTestCase;
 use LearnositySdk\Exceptions\ValidationException;
 use LearnositySdk\Fixtures\ParamsFixture;
-use LearnositySdk\Request\Init;
 
 class LegacyPreHashStringTest extends AbstractTestCase
 {
@@ -41,34 +40,63 @@ class LegacyPreHashStringTest extends AbstractTestCase
      * > */
     public function preHashStringProvider()
     {
-        Init::disableTelemetry();
         $testCases = [];
 
-        $v1Compat = false;
         $requestAsString = true;
 
-        foreach (LegacyPreHashString::getSupportedServices() as $service) {
+        /* Hardcoded prehash strings generated with the last version of the legacy code,
+         * based on queries from the ParamsFixture, depending on v1Compat mode */
+        $preHashStrings = [
+            false => [
+                'assess' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_$ANONYMIZED_USER_ID',
+                'author' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_{"mode":"item_list","config":{"item_list":{"item":{"status":true}}},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}',
+                'authoraide' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_{"config":{"test-attribute":"test"},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}',
+                'data' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_{"limit":100}_get',
+                'events' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528',
+                'items' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_$ANONYMIZED_USER_ID_{"user_id":"$ANONYMIZED_USER_ID","rendering_type":"assess","name":"Items API demo - assess activity demo","state":"initial","activity_id":"items_assess_demo","session_id":"demo_session_uuid","type":"submit_practice","config":{"configuration":{"responsive_regions":true},"navigation":{"scrolling_indicator":true},"regions":"main","time":{"show_pause":true,"max_time":300},"title":"ItemsAPI Assess Isolation Demo","subtitle":"Testing Subtitle Text"},"items":["Demo3"]}',
+                'questions' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_$ANONYMIZED_USER_ID',
+                'reports' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_{"reports":[{"id":"report-1","type":"sessions-summary","user_id":"$ANONYMIZED_USER_ID","session_ids":["AC023456-2C73-44DC-82DA28894FCBC3BF"]}]}',
+            ],
+            true => [
+                /* Generated from a the ParamsFixture knowing that a v1 signature was generated correctly */
+                'assess' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_$ANONYMIZED_USER_ID_74c5fd430cf1242a527f6223aebd42d30464be22',
+                'author' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_74c5fd430cf1242a527f6223aebd42d30464be22_{"mode":"item_list","config":{"item_list":{"item":{"status":true}}},"user":{"id":"walterwhite","firstname":"walter","lastname":"white"}}',
+                'authoraide' => null, /* no need for v1 compat, let's make this explicit */
+                'data' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_74c5fd430cf1242a527f6223aebd42d30464be22_{"limit":100}_get',
+                'events' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_74c5fd430cf1242a527f6223aebd42d30464be22',
+                'items' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_$ANONYMIZED_USER_ID_74c5fd430cf1242a527f6223aebd42d30464be22_{"user_id":"$ANONYMIZED_USER_ID","rendering_type":"assess","name":"Items API demo - assess activity demo","state":"initial","activity_id":"items_assess_demo","session_id":"demo_session_uuid","type":"submit_practice","config":{"configuration":{"responsive_regions":true},"navigation":{"scrolling_indicator":true},"regions":"main","time":{"show_pause":true,"max_time":300},"title":"ItemsAPI Assess Isolation Demo","subtitle":"Testing Subtitle Text"},"items":["Demo3"]}',
+                'questions' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_$ANONYMIZED_USER_ID_74c5fd430cf1242a527f6223aebd42d30464be22',
+                'reports' => 'yis0TYCu7U9V4o7M_localhost_20140626-0528_74c5fd430cf1242a527f6223aebd42d30464be22_{"reports":[{"id":"report-1","type":"sessions-summary","user_id":"$ANONYMIZED_USER_ID","session_ids":["AC023456-2C73-44DC-82DA28894FCBC3BF"]}]}',
+            ],
+        ];
+
+        foreach ([true, false] as $v1Compat) {
+            foreach (LegacyPreHashString::getSupportedServices() as $service) {
             $camelCaseService = str_replace(
                 ' ',
                 '',
                 ucwords(str_replace('-', ' ', $service))
             );
             $getParams = 'getWorking' . $camelCaseService . 'ApiParams';
-            $tc = array_merge(
-                ParamsFixture::$getParams(true),
-                [
+                $tc = array_merge(
+                    ParamsFixture::$getParams(true),
+                    [
                     'v1Compat' => $v1Compat,
                     'requestAsString' => $requestAsString,
-                ]
-            );
+                    ]
+                );
 
-            $init = new Init($service, $tc['security'], $tc['secret'], $tc['request'], $tc['action']);
-            $tc['expected'] = $init->generatePreHashString();
+                $tc['expected'] = $preHashStrings[$v1Compat][$service];
 
-            $testCases["api-{$service}"] = $tc;
+                if (is_null($case['expected'])) {
+                    /* New APIs don't need v1Compat support */
+                    continue;
+                }
+
+                $testCases["api-{$service}" . ($v1Compat ? '-v1Compat' : '')] = $tc;
+            }
         }
 
-        Init::enableTelemetry();
         return $testCases;
     }
 }

--- a/tests/Utils/JsonTest.php
+++ b/tests/Utils/JsonTest.php
@@ -10,7 +10,7 @@ class JsonTest extends AbstractTestCase
     public function testCheckError()
     {
         $result = Json::checkError();
-        $this->assertTrue( is_null($result) || is_string($result) );
+        $this->assertTrue(is_null($result) || is_string($result));
     }
 
     public function dataProviderEncode(): array
@@ -64,7 +64,7 @@ class JsonTest extends AbstractTestCase
         ];
 
         $expectedResult =
-<<<JSON
+        <<<JSON
 {
     "test": "hello-world"
 }


### PR DESCRIPTION
This PR:
* introduces a separate PreHashString service concept, and moves the current implementation into a LegacyPrehashStringService
* removes the ability to inject signature factories into the Init object, as using the latest version is a deliberate choice
* reintroduces v1 signature tests
* moves the tests params to a separate fixture provider
* ensures that things we want to test for backward compatibility are hardcoded strings, rather than generated on the fly
* refreshes the phpunit config
* adds linting tools
* lints the lot for good measure
* add a github workflow to run those tests on PR

It may help to review this PR commit by commit, as they build on top of each other.

## Checklist

- [x] Feature
- [ ] Bug
- [x] Refactor

- [x] ChangeLog.md updated

- [x] Tests added
- [x] All testsuite passes
- [x] `make dist` completed successfully
